### PR TITLE
Fix Vercel Stripe payment link route

### DIFF
--- a/api/runtime.js
+++ b/api/runtime.js
@@ -55,14 +55,40 @@ function runtimePayload(extra = {}) {
   };
 }
 
+function isValidStripeUrl(url) {
+  try {
+    const parsed = new URL(url);
+    // Only allow HTTPS
+    if (parsed.protocol !== 'https:') {
+      return false;
+    }
+    // Allow Stripe checkout and payment link domains
+    const hostname = parsed.hostname;
+    return hostname === 'checkout.stripe.com' ||
+           hostname === 'pay.stripe.com' ||
+           hostname.endsWith('.stripe.com');
+  } catch (e) {
+    return false;
+  }
+}
+
 function configuredStripeLink() {
-  return (
-    process.env.STRIPE_PAYMENT_LINK ||
-    process.env.STRIPE_DEVICE_LINK_URL ||
-    process.env.SKYGRID_STRIPE_LINK ||
-    process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK ||
-    ''
-  ).trim();
+  const candidates = [
+    process.env.STRIPE_PAYMENT_LINK,
+    process.env.STRIPE_DEVICE_LINK_URL,
+    process.env.SKYGRID_STRIPE_LINK,
+    process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK
+  ];
+  
+  for (const candidate of candidates) {
+    if (candidate) {
+      const trimmed = candidate.trim();
+      if (isValidStripeUrl(trimmed)) {
+        return trimmed;
+      }
+    }
+  }
+  return '';
 }
 
 function stripeStatusPayload(req) {

--- a/api/runtime.js
+++ b/api/runtime.js
@@ -139,7 +139,9 @@ function stripeDeviceLinkPayload(req) {
 
 export default function handler(req, res) {
   const url = new URL(req.url, `https://${req.headers.host || 'localhost'}`);
-  let path = url.searchParams.get('__path') || url.pathname;
+  // Use Vercel's x-rewrote-url header to get the original path when URL is rewritten.
+  // This prevents path injection attacks via query parameters.
+  let path = req.headers['x-rewrote-url'] || url.pathname;
   path = path.replace(/\/$/, '') || '/';
 
   if (path === '/') {

--- a/api/runtime.js
+++ b/api/runtime.js
@@ -1,4 +1,4 @@
-const VERSION = '1.3.5-smoke-runtime';
+const VERSION = '1.3.7-stripe-link-runtime';
 
 function sendJson(res, statusCode, body) {
   res.statusCode = statusCode;
@@ -7,6 +7,15 @@ function sendJson(res, statusCode, body) {
   res.setHeader('X-SkyGrid-Network', 'Aura-Core');
   res.setHeader('X-Phoenix-Version', VERSION);
   res.end(JSON.stringify(body, null, 2));
+}
+
+function sendRedirect(res, location) {
+  res.statusCode = 302;
+  res.setHeader('Location', location);
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.setHeader('X-SkyGrid-Network', 'Aura-Core');
+  res.setHeader('X-Phoenix-Version', VERSION);
+  res.end();
 }
 
 function sendHome(res) {
@@ -26,6 +35,7 @@ function sendHome(res) {
   <main>
     <h1>SKYGRID Runtime</h1>
     <p>Aura-Core SKYGRID runtime preflight active.</p>
+    <p><a href="/api/stripe/device-link?redirect=1">Open Stripe payment link</a></p>
   </main>
 </body>
 </html>`);
@@ -45,9 +55,66 @@ function runtimePayload(extra = {}) {
   };
 }
 
+function configuredStripeLink() {
+  return (
+    process.env.STRIPE_PAYMENT_LINK ||
+    process.env.STRIPE_DEVICE_LINK_URL ||
+    process.env.SKYGRID_STRIPE_LINK ||
+    process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK ||
+    ''
+  ).trim();
+}
+
+function stripeStatusPayload(req) {
+  const link = configuredStripeLink();
+  return runtimePayload({
+    service: 'SkyGrid Stripe Link',
+    status: link ? 'configured' : 'missing_env',
+    configured: Boolean(link),
+    publicEndpoint: '/api/stripe/device-link',
+    redirectEndpoint: '/api/stripe/device-link?redirect=1',
+    requiredEnvironmentOneOf: [
+      'STRIPE_PAYMENT_LINK',
+      'STRIPE_DEVICE_LINK_URL',
+      'SKYGRID_STRIPE_LINK',
+      'NEXT_PUBLIC_STRIPE_PAYMENT_LINK'
+    ],
+    host: req.headers.host || null,
+    guardrails: [
+      'Uses Stripe hosted Payment Link or Checkout URL only',
+      'No card data is handled by this Vercel runtime',
+      'No Stripe secret key is exposed to the browser',
+      'Fails closed when no approved payment link is configured'
+    ]
+  });
+}
+
+function stripeDeviceLinkPayload(req) {
+  const link = configuredStripeLink();
+  if (!link) {
+    return {
+      statusCode: 503,
+      body: stripeStatusPayload(req)
+    };
+  }
+
+  return {
+    statusCode: 200,
+    body: runtimePayload({
+      service: 'SkyGrid Stripe Device Link',
+      status: 'ready',
+      provider: 'stripe',
+      checkoutUrl: link,
+      redirectUrl: '/api/stripe/device-link?redirect=1',
+      nextStep: 'Open redirectUrl to send the user to the configured Stripe-hosted payment link.'
+    })
+  };
+}
+
 export default function handler(req, res) {
   const url = new URL(req.url, `https://${req.headers.host || 'localhost'}`);
-  const path = url.pathname.replace(/\/$/, '') || '/';
+  let path = url.searchParams.get('__path') || url.pathname;
+  path = path.replace(/\/$/, '') || '/';
 
   if (path === '/') {
     return sendHome(res);
@@ -62,9 +129,25 @@ export default function handler(req, res) {
         healthAlias: '/health.json',
         helm: '/api/skygrid/helm?command=status',
         provenance: '/api/skygrid/provenance',
-        aws: '/api/skygrid/aws'
+        aws: '/api/skygrid/aws',
+        stripeStatus: '/api/stripe/status',
+        stripeDeviceLink: '/api/stripe/device-link'
       }
     }));
+  }
+
+  if (path === '/api/stripe/status') {
+    return sendJson(res, 200, stripeStatusPayload(req));
+  }
+
+  if (path === '/api/stripe/device-link') {
+    const link = configuredStripeLink();
+    if (link && url.searchParams.get('redirect') === '1') {
+      return sendRedirect(res, link);
+    }
+
+    const payload = stripeDeviceLinkPayload(req);
+    return sendJson(res, payload.statusCode, payload.body);
   }
 
   if (path === '/api/skygrid/helm') {

--- a/vercel.json
+++ b/vercel.json
@@ -72,6 +72,14 @@
     {
       "source": "/api/highway/postman",
       "destination": "/api/runtime"
+    },
+    {
+      "source": "/api/stripe/status",
+      "destination": "/api/runtime"
+    },
+    {
+      "source": "/api/stripe/device-link",
+      "destination": "/api/runtime"
     }
   ],
   "cleanUrls": true,


### PR DESCRIPTION
Fixes the Vercel Stripe payment-link problem by adding explicit runtime support for Stripe link health and redirect routes.

Changes:
- Adds `/api/stripe/status` JSON health endpoint
- Adds `/api/stripe/device-link` JSON endpoint
- Adds `/api/stripe/device-link?redirect=1` 302 redirect support
- Reads one of these approved Vercel environment variables:
  - `STRIPE_PAYMENT_LINK`
  - `STRIPE_DEVICE_LINK_URL`
  - `SKYGRID_STRIPE_LINK`
  - `NEXT_PUBLIC_STRIPE_PAYMENT_LINK`
- Keeps card handling out of the runtime; Stripe hosted checkout/payment link remains the payment surface
- Fails closed with 503 when no payment link env var is configured

Operational note:
Set the Stripe hosted payment-link URL in Vercel as `STRIPE_PAYMENT_LINK` for Production, Preview, and Development as needed, then redeploy.