### PR TITLE
Fix SKYGRID ramp smoke test routes

### DIFF
--- a/scripts/skygrid-ramp-smoke.sh
+++ b/scripts/skygrid-ramp-smoke.sh
@@ -45,6 +45,36 @@ check_required() {
   rm -f "$body_file"
 }
 
+check_post_accepted() {
+  local path="$1"
+  local url="${BASE_URL}${path}"
+
+  local body_file
+  body_file="$(mktemp)"
+
+  local code
+  code="$(curl "${curl_args[@]}" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d '{"source":"github-smoke","type":"system-health","severity":"normal"}' \
+    -o "$body_file" \
+    -w "%{http_code}" \
+    "$url" || true)"
+
+  echo "== ${path} HTTP ${code}"
+
+  if [[ "$code" != "202" && "$code" != "200" ]]; then
+    echo "FAIL: ${url} did not accept smoke payload"
+    cat "$body_file" || true
+    rm -f "$body_file"
+    exit 1
+  fi
+
+  cat "$body_file" || true
+  echo ""
+  rm -f "$body_file"
+}
+
 check_optional() {
   local path="$1"
   local url="${BASE_URL}${path}"
@@ -59,11 +89,26 @@ check_optional() {
   fi
 }
 
-check_required "/api/health"
+# Required routes must match config/skygrid-route-manifest.json and api/runtime.mjs.
+check_required "/"
+check_required "/health.json"
+check_required "/api/skygrid/status"
+check_required "/api/highway/status"
+check_required "/api/failover/status"
+check_required "/api/autodrill/latest"
 
-check_optional "/"
-check_optional "/health.json"
-check_optional "/api/skygrid/provenance"
+# Required POST acceptance routes for proof-of-intake and advisory routing.
+check_post_accepted "/api/skygrid/intake"
+check_post_accepted "/api/aura-core/decide"
+check_post_accepted "/api/agent/signals"
+
+# Optional dashboard/business routes.
+check_optional "/dashboard/command-center"
+check_optional "/dashboard/validation-panel"
+check_optional "/dashboard/deployment-review"
+check_optional "/dashboard/receipts"
+check_optional "/api/highway/postman"
+check_optional "/api/pay/quote?amount=25"
 
 echo ""
 echo "SKYGRID ramp smoke completed successfully."


### PR DESCRIPTION
## Summary
- Aligns `scripts/skygrid-ramp-smoke.sh` with the implemented SKYGRID Emergency Data On-Ramp routes in `config/skygrid-route-manifest.json` and `api/runtime.mjs`.
- Replaces stale checks for `/api/health` and `/api/skygrid/provenance` with active required routes: `/health.json`, `/api/skygrid/status`, `/api/highway/status`, `/api/failover/status`, and `/api/autodrill/latest`.
- Adds POST smoke coverage for `/api/skygrid/intake`, `/api/aura-core/decide`, and `/api/agent/signals`.
- Keeps dashboard and business/proof routes as optional checks.

## Why
The current smoke script checks routes that are not declared in the manifest/runtime, which can make CI fail even when the deployed on-ramp is healthy.

## Validation
Expected workflow path:
1. `node --check api/runtime.mjs`
2. Postman JSON parse checks
3. `node scripts/verify-skygrid-manifest-sync.mjs`
4. `bash scripts/skygrid-ramp-smoke.sh "$SKYGRID_BASE_URL"`

This patch only changes the smoke script and does not alter production routing, wallet behavior, AWS forwarding, or failover gates.