### PR TITLE
Fix public pay quote route check

### DIFF
--- a/api/pay/quote.js
+++ b/api/pay/quote.js
@@ -1,0 +1,49 @@
+export default function handler(req, res) {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-SKYGRID-Product", "SKYGRID Emergency Data On-Ramp");
+
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({
+      ok: false,
+      system: "SKYGRID Emergency Data On-Ramp",
+      route: "/api/pay/quote",
+      error: "method_not_allowed",
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  const rawAmount = Array.isArray(req.query?.amount) ? req.query.amount[0] : req.query?.amount;
+  const amount = Number(rawAmount ?? 0);
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return res.status(400).json({
+      ok: false,
+      system: "SKYGRID Emergency Data On-Ramp",
+      route: "/api/pay/quote",
+      error: "invalid_amount",
+      message: "Provide a positive numeric amount, for example /api/pay/quote?amount=25.",
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  const currency = String(
+    Array.isArray(req.query?.currency) ? req.query.currency[0] : req.query?.currency || "USD"
+  ).toUpperCase();
+  const feePercent = 3;
+  const fee = Number((amount * (feePercent / 100)).toFixed(2));
+
+  return res.status(200).json({
+    ok: true,
+    system: "SKYGRID Emergency Data On-Ramp",
+    route: "/api/pay/quote",
+    status: "quote_ready",
+    amount,
+    currency,
+    feePercent,
+    fee,
+    estimatedNet: Number((amount - fee).toFixed(2)),
+    quoteOnly: true,
+    timestamp: new Date().toISOString()
+  });
+}


### PR DESCRIPTION
## Summary

Adds a file-based Vercel API handler for `GET /api/pay/quote?amount=25` so the public route checker stops receiving a 404 on the working Vercel deployment.

## Why

The route already exists inside `api/runtime.mjs`, but the currently passing public routes are file-based Vercel functions/static assets. The checker is calling `/api/pay/quote?amount=25` directly, so this adds the matching file-based handler at `api/pay/quote.js`.

## Scope

- Adds `api/pay/quote.js`
- Returns `200` JSON for valid positive amounts
- Returns `400` JSON for missing/invalid amounts
- Returns `405` JSON for non-GET methods
- Keeps the response quote-only

## Remaining issue outside this PR

`aurcore.skygrid-protocol.net` is still a domain/alias mapping issue: the Vercel project data I inspected does not show that custom domain attached to the active `aura-core` project, while the Vercel-hosted routes are alive. That needs a Vercel domain assignment or DNS/alias correction.

## Testing

Expected after deployment:

```text
GET https://aura-core.vercel.app/api/pay/quote?amount=25 -> 200
```
