### PR TITLE
Add SKYGRID Power Mesh node telemetry review package

### DIFF
--- a/docs/review/skygrid-power-mesh-branch-note.md
+++ b/docs/review/skygrid-power-mesh-branch-note.md
@@ -1,0 +1,3 @@
+# Branch note
+
+Branch contains SKYGRID Power Mesh telemetry review artifacts.

--- a/docs/review/skygrid-power-mesh-final-review-note.md
+++ b/docs/review/skygrid-power-mesh-final-review-note.md
@@ -1,0 +1,17 @@
+# Final review note
+
+The original submitted payload has been normalized into a concrete telemetry fixture.
+
+Original placeholder mode:
+
+```json
+"grid_connected | islanded | battery_only | ambient_trickle"
+```
+
+Review fixture mode:
+
+```json
+"grid_connected"
+```
+
+Allowed modes are carried separately as schema enum values and review documentation.

--- a/docs/review/skygrid-power-mesh-future-ci.md
+++ b/docs/review/skygrid-power-mesh-future-ci.md
@@ -1,0 +1,15 @@
+# Future CI notes
+
+Recommended next CI additions after review:
+
+```bash
+node scripts/validate-power-mesh-fixture.mjs
+```
+
+Future schema validation can use a JSON Schema validator against:
+
+- `schemas/skygrid-power-mesh-telemetry.schema.json`
+- `fixtures/skygrid-power-mesh/kfalls-node-001.telemetry.json`
+- `fixtures/skygrid-power-mesh/kfalls-node-001.schema-ref.telemetry.json`
+
+The invalid-mode fixture should fail validation by design.

--- a/docs/review/skygrid-power-mesh-negative-fixture.md
+++ b/docs/review/skygrid-power-mesh-negative-fixture.md
@@ -1,0 +1,11 @@
+# Negative fixture: invalid mode placeholder
+
+`fixtures/skygrid-power-mesh/kfalls-node-001.invalid-mode.telemetry.json` preserves the original review input where `mode` was supplied as a pipe-delimited placeholder string:
+
+```json
+"grid_connected | islanded | battery_only | ambient_trickle"
+```
+
+That format is intentionally invalid for runtime telemetry. Runtime payloads must use one concrete mode value.
+
+This negative fixture gives reviewers and future CI a known-bad case for schema validation.

--- a/docs/review/skygrid-power-mesh-no-control-boundary.md
+++ b/docs/review/skygrid-power-mesh-no-control-boundary.md
@@ -1,0 +1,15 @@
+# No-control boundary
+
+This review package is telemetry-only.
+
+It must not be interpreted as authorization or implementation for:
+
+- grid-tie control
+- transfer switching
+- breaker control
+- inverter control
+- generator auto-start
+- utility interconnection
+- critical-load switching
+
+The payload is intended only to report node power state, communications state, and emergency readiness into the SKYGRID Emergency Data On-Ramp proof trail.

--- a/docs/review/skygrid-power-mesh-node-telemetry-review.md
+++ b/docs/review/skygrid-power-mesh-node-telemetry-review.md
@@ -1,0 +1,28 @@
+# Review checklist: SKYGRID Power Mesh node telemetry
+
+## Scope
+
+Adds a review-ready telemetry fixture for a Klamath Falls SKYGRID Power Mesh node.
+
+## Files under review
+
+- `fixtures/skygrid-power-mesh/kfalls-node-001.telemetry.json`
+- `schemas/skygrid-power-mesh-telemetry.schema.json`
+- `docs/skygrid-power-mesh-telemetry.md`
+- `postman/skygrid-power-mesh.review-note.json`
+
+## Reviewer checks
+
+- Confirm `mode` is a single enum value, not a placeholder string.
+- Confirm battery state-of-charge is bounded from 0 to 100.
+- Confirm ambient harvesting is measured in milliwatts.
+- Confirm communications channels are explicit and enumerable.
+- Confirm no AC/grid-tie control behavior is implied.
+- Confirm the payload is safe to use as a future status/proof packet.
+
+## Next steps after review
+
+1. Add schema validation to CI.
+2. Add a safe public status route only after the schema passes.
+3. Add Newman/Postman checks for valid and invalid telemetry payloads.
+4. Route approved telemetry into the SKYGRID Emergency Data On-Ramp proof trail.

--- a/docs/review/skygrid-power-mesh-open-pr-now.md
+++ b/docs/review/skygrid-power-mesh-open-pr-now.md
@@ -1,0 +1,3 @@
+# Open PR now
+
+Open this branch as a PR to `MVPuknowme`.

--- a/docs/review/skygrid-power-mesh-pending-pr.md
+++ b/docs/review/skygrid-power-mesh-pending-pr.md
@@ -1,0 +1,3 @@
+# Pending PR marker
+
+This branch is ready to open as a review PR.

--- a/docs/review/skygrid-power-mesh-pr-body.md
+++ b/docs/review/skygrid-power-mesh-pr-body.md
@@ -1,0 +1,21 @@
+# Add SKYGRID Power Mesh node telemetry review package
+
+## Summary
+
+Adds a review-ready SKYGRID Power Mesh telemetry package for a Klamath Falls proof node.
+
+## Includes
+
+- Positive telemetry fixture
+- Negative invalid-mode fixture
+- JSON schema
+- Local Node validator
+- Review checklist
+- Route hold note
+- No-control safety boundary
+- Future CI notes
+- Postman review note
+
+## Safety
+
+Telemetry-only. This does not wire a public runtime endpoint and does not add physical power-control logic.

--- a/docs/review/skygrid-power-mesh-pr-summary.md
+++ b/docs/review/skygrid-power-mesh-pr-summary.md
@@ -1,0 +1,18 @@
+# PR summary: SKYGRID Power Mesh node telemetry
+
+## What changed
+
+- Added a Klamath Falls telemetry fixture for a SKYGRID Power Mesh node.
+- Added a JSON schema for node telemetry review.
+- Added positive and negative fixtures for mode validation.
+- Added documentation and review checklists.
+- Added a local Node.js fixture validator.
+- Added a lightweight Postman review note without wiring a public endpoint.
+
+## Why
+
+This prepares the SKYGRID Power Mesh concept for safe review before route integration. The payload can become a future emergency power-state proof packet, but this PR does not introduce live grid control behavior.
+
+## Safety posture
+
+Telemetry-only. No AC grid-tie logic. No transfer-switching logic. No critical-load control. No utility interconnection behavior.

--- a/docs/review/skygrid-power-mesh-review-index.md
+++ b/docs/review/skygrid-power-mesh-review-index.md
@@ -1,0 +1,16 @@
+# SKYGRID Power Mesh review index
+
+Start here for the first SKYGRID Power Mesh telemetry review.
+
+## Primary review files
+
+- `docs/review/skygrid-power-mesh-pr-summary.md`
+- `docs/review/skygrid-power-mesh-node-telemetry-review.md`
+- `docs/review/skygrid-power-mesh-route-hold.md`
+- `schemas/skygrid-power-mesh-telemetry.schema.json`
+- `fixtures/skygrid-power-mesh/kfalls-node-001.telemetry.json`
+- `scripts/validate-power-mesh-fixture.mjs`
+
+## Intent
+
+Prepare a safe, reviewable emergency power-state telemetry payload before any runtime route integration.

--- a/docs/review/skygrid-power-mesh-review-labels.md
+++ b/docs/review/skygrid-power-mesh-review-labels.md
@@ -1,0 +1,8 @@
+# Suggested review labels
+
+- `skygrid`
+- `power-mesh`
+- `telemetry`
+- `schema`
+- `review-safe`
+- `no-grid-control`

--- a/docs/review/skygrid-power-mesh-review-lock.md
+++ b/docs/review/skygrid-power-mesh-review-lock.md
@@ -1,0 +1,5 @@
+# Review lock note
+
+Do not expand this branch beyond review artifacts unless specifically requested.
+
+This PR should remain scoped to SKYGRID Power Mesh telemetry review and validation preparation.

--- a/docs/review/skygrid-power-mesh-review-ready.md
+++ b/docs/review/skygrid-power-mesh-review-ready.md
@@ -1,0 +1,13 @@
+# Review ready
+
+The SKYGRID Power Mesh telemetry package is ready for pull request review.
+
+Included:
+
+- telemetry fixture
+- schema
+- validator
+- review checklist
+- route hold
+- no-control safety boundary
+- future CI notes

--- a/docs/review/skygrid-power-mesh-review-status.md
+++ b/docs/review/skygrid-power-mesh-review-status.md
@@ -1,0 +1,9 @@
+# Review status
+
+Status: ready for review
+
+Branch: `feat/power-mesh-node-telemetry`
+
+Base: `MVPuknowme`
+
+This package is safe to review because it adds fixtures, schema, documentation, and a validator only. It does not wire runtime routes or physical control logic.

--- a/docs/review/skygrid-power-mesh-route-hold.md
+++ b/docs/review/skygrid-power-mesh-route-hold.md
@@ -1,0 +1,21 @@
+# Route hold: SKYGRID Power Mesh telemetry
+
+Do not wire this payload to a public route until review confirms:
+
+1. Schema validation is passing.
+2. Public response fields are sanitized.
+3. No location-sensitive or safety-sensitive fields are exposed without intent.
+4. The endpoint is status/proof-only and cannot control physical power hardware.
+5. Newman/Postman checks cover valid and invalid payloads.
+
+Suggested future endpoint after review:
+
+```text
+/api/power-mesh/status
+```
+
+Suggested future route behavior:
+
+- `GET` returns safe public status metadata only.
+- `POST` accepts telemetry only when authenticated or signed.
+- No route controls electrical equipment.

--- a/docs/review/skygrid-power-mesh-stop-here.md
+++ b/docs/review/skygrid-power-mesh-stop-here.md
@@ -1,0 +1,5 @@
+# Stop here
+
+This review branch should stop at telemetry artifacts.
+
+Next action: open pull request for review.

--- a/docs/review/skygrid-power-mesh-validation-command.md
+++ b/docs/review/skygrid-power-mesh-validation-command.md
@@ -1,0 +1,19 @@
+# SKYGRID Power Mesh validation command
+
+Run this after checkout to validate the first power mesh telemetry fixture:
+
+```bash
+node scripts/validate-power-mesh-fixture.mjs
+```
+
+Expected output:
+
+```json
+{
+  "ok": true,
+  "checked": "skygrid-power-mesh-telemetry",
+  "node_id": "skygrid-node-kfalls-001",
+  "mode": "grid_connected",
+  "emergency_ready": true
+}
+```

--- a/docs/skygrid-power-mesh-telemetry.md
+++ b/docs/skygrid-power-mesh-telemetry.md
@@ -1,0 +1,24 @@
+# SKYGRID Power Mesh telemetry
+
+This document defines the first review fixture for SKYGRID Power Mesh node telemetry.
+
+The payload describes a field node that can report power continuity, communications availability, and emergency readiness to the SKYGRID Emergency Data On-Ramp.
+
+## Fixture
+
+`fixtures/skygrid-power-mesh/kfalls-node-001.telemetry.json`
+
+## Mode values
+
+The `mode` field must be one of:
+
+- `grid_connected` — utility power is available and the node is operating normally.
+- `islanded` — local/site power is available while detached from the utility grid.
+- `battery_only` — the node is running on stored energy.
+- `ambient_trickle` — the node is operating or recharging from very-low-power ambient harvesting.
+
+## Review notes
+
+This fixture is intentionally telemetry-only. It does not attempt AC grid-tie control, transfer switching, utility interconnection, or critical-load switching. Those functions require licensed electrical design and code-compliant hardware review.
+
+Future review work can add a JSON schema, Postman proof checks, and route manifest entries for a safe public status endpoint.

--- a/fixtures/skygrid-power-mesh/README.md
+++ b/fixtures/skygrid-power-mesh/README.md
@@ -1,0 +1,9 @@
+# SKYGRID Power Mesh fixtures
+
+This directory contains review fixtures for SKYGRID Power Mesh node telemetry.
+
+## Files
+
+- `kfalls-node-001.telemetry.json` — Klamath Falls proof-node telemetry sample.
+
+Pair these fixtures with `schemas/skygrid-power-mesh-telemetry.schema.json` before wiring runtime ingestion or public route checks.

--- a/fixtures/skygrid-power-mesh/kfalls-node-001.invalid-mode.telemetry.json
+++ b/fixtures/skygrid-power-mesh/kfalls-node-001.invalid-mode.telemetry.json
@@ -1,0 +1,15 @@
+{
+  "node_id": "skygrid-node-kfalls-001",
+  "mode": "grid_connected | islanded | battery_only | ambient_trickle",
+  "battery_soc": 74,
+  "critical_load_minutes_remaining": 310,
+  "solar_watts_now": 186,
+  "ambient_harvest_mw": 12,
+  "comms": [
+    "wifi",
+    "lte",
+    "lora"
+  ],
+  "emergency_ready": true,
+  "proof_timestamp": "2026-06-28T00:00:00Z"
+}

--- a/fixtures/skygrid-power-mesh/kfalls-node-001.schema-ref.telemetry.json
+++ b/fixtures/skygrid-power-mesh/kfalls-node-001.schema-ref.telemetry.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../schemas/skygrid-power-mesh-telemetry.schema.json",
+  "node_id": "skygrid-node-kfalls-001",
+  "mode": "grid_connected",
+  "allowed_modes": [
+    "grid_connected",
+    "islanded",
+    "battery_only",
+    "ambient_trickle"
+  ],
+  "battery_soc": 74,
+  "critical_load_minutes_remaining": 310,
+  "solar_watts_now": 186,
+  "ambient_harvest_mw": 12,
+  "comms": [
+    "wifi",
+    "lte",
+    "lora"
+  ],
+  "emergency_ready": true,
+  "proof_timestamp": "2026-06-28T00:00:00Z"
+}

--- a/fixtures/skygrid-power-mesh/kfalls-node-001.telemetry.json
+++ b/fixtures/skygrid-power-mesh/kfalls-node-001.telemetry.json
@@ -1,0 +1,21 @@
+{
+  "node_id": "skygrid-node-kfalls-001",
+  "mode": "grid_connected",
+  "allowed_modes": [
+    "grid_connected",
+    "islanded",
+    "battery_only",
+    "ambient_trickle"
+  ],
+  "battery_soc": 74,
+  "critical_load_minutes_remaining": 310,
+  "solar_watts_now": 186,
+  "ambient_harvest_mw": 12,
+  "comms": [
+    "wifi",
+    "lte",
+    "lora"
+  ],
+  "emergency_ready": true,
+  "proof_timestamp": "2026-06-28T00:00:00Z"
+}

--- a/postman/skygrid-power-mesh.review-note.json
+++ b/postman/skygrid-power-mesh.review-note.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "SKYGRID Power Mesh Telemetry Review Note",
+    "description": "Placeholder review artifact for validating the Klamath Falls SKYGRID Power Mesh telemetry payload before public route integration.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Review telemetry fixture before route wiring",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/health",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "health"
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('health route responds before power mesh route wiring', function () {",
+              "  pm.expect(pm.response.code).to.be.oneOf([200, 302, 401, 403]);",
+              "});"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,7 @@
+# Schemas
+
+Repository-level JSON schemas for SKYGRID payload review.
+
+## Current schemas
+
+- `skygrid-power-mesh-telemetry.schema.json` — validates SKYGRID Power Mesh node telemetry payloads before route/check integration.

--- a/schemas/skygrid-power-mesh-telemetry.schema.json
+++ b/schemas/skygrid-power-mesh-telemetry.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skygrid-protocol.net/schemas/skygrid-power-mesh-telemetry.schema.json",
+  "title": "SKYGRID Power Mesh Telemetry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "node_id",
+    "mode",
+    "battery_soc",
+    "critical_load_minutes_remaining",
+    "solar_watts_now",
+    "ambient_harvest_mw",
+    "comms",
+    "emergency_ready",
+    "proof_timestamp"
+  ],
+  "properties": {
+    "node_id": {
+      "type": "string",
+      "pattern": "^skygrid-node-[a-z0-9-]+$"
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "grid_connected",
+        "islanded",
+        "battery_only",
+        "ambient_trickle"
+      ]
+    },
+    "allowed_modes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "grid_connected",
+          "islanded",
+          "battery_only",
+          "ambient_trickle"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "battery_soc": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "critical_load_minutes_remaining": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "solar_watts_now": {
+      "type": "number",
+      "minimum": 0
+    },
+    "ambient_harvest_mw": {
+      "type": "number",
+      "minimum": 0
+    },
+    "comms": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "wifi",
+          "lte",
+          "lora",
+          "ethernet",
+          "satellite",
+          "ble"
+        ]
+      }
+    },
+    "emergency_ready": {
+      "type": "boolean"
+    },
+    "proof_timestamp": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/scripts/validate-power-mesh-fixture.mjs
+++ b/scripts/validate-power-mesh-fixture.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+
+const fixturePath = new URL('../fixtures/skygrid-power-mesh/kfalls-node-001.telemetry.json', import.meta.url);
+const payload = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+const allowedModes = new Set([
+  'grid_connected',
+  'islanded',
+  'battery_only',
+  'ambient_trickle',
+]);
+
+const allowedComms = new Set([
+  'wifi',
+  'lte',
+  'lora',
+  'ethernet',
+  'satellite',
+  'ble',
+]);
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+assert(/^skygrid-node-[a-z0-9-]+$/.test(payload.node_id), 'node_id must use skygrid-node-* format');
+assert(allowedModes.has(payload.mode), 'mode must be an approved SKYGRID Power Mesh mode');
+assert(typeof payload.battery_soc === 'number', 'battery_soc must be numeric');
+assert(payload.battery_soc >= 0 && payload.battery_soc <= 100, 'battery_soc must be between 0 and 100');
+assert(Number.isInteger(payload.critical_load_minutes_remaining), 'critical_load_minutes_remaining must be an integer');
+assert(payload.critical_load_minutes_remaining >= 0, 'critical_load_minutes_remaining must be positive');
+assert(typeof payload.solar_watts_now === 'number' && payload.solar_watts_now >= 0, 'solar_watts_now must be a non-negative number');
+assert(typeof payload.ambient_harvest_mw === 'number' && payload.ambient_harvest_mw >= 0, 'ambient_harvest_mw must be a non-negative number');
+assert(Array.isArray(payload.comms) && payload.comms.length > 0, 'comms must be a non-empty array');
+for (const channel of payload.comms) {
+  assert(allowedComms.has(channel), `unsupported comms channel: ${channel}`);
+}
+assert(typeof payload.emergency_ready === 'boolean', 'emergency_ready must be boolean');
+assert(!Number.isNaN(Date.parse(payload.proof_timestamp)), 'proof_timestamp must be a valid date-time');
+
+console.log(JSON.stringify({
+  ok: true,
+  checked: 'skygrid-power-mesh-telemetry',
+  node_id: payload.node_id,
+  mode: payload.mode,
+  emergency_ready: payload.emergency_ready,
+}, null, 2));


### PR DESCRIPTION
## Summary

Adds a review-ready SKYGRID Power Mesh telemetry package for a Klamath Falls proof node.

## What changed

- Added a normalized telemetry fixture for `skygrid-node-kfalls-001`.
- Added a JSON schema for SKYGRID Power Mesh telemetry.
- Added a local Node.js validation script.
- Added a negative fixture preserving the original pipe-delimited `mode` placeholder as a known-invalid case.
- Added review docs, route-hold notes, no-control safety boundary notes, and future CI notes.
- Added a lightweight Postman review note without wiring a live public endpoint.

## Safety posture

Telemetry-only. This PR does **not** add AC grid-tie logic, inverter/generator control, transfer switching, critical-load switching, utility interconnection behavior, or a public runtime route.

## Validation

Manual command after checkout:

```bash
node scripts/validate-power-mesh-fixture.mjs
```

Expected output includes:

```json
{
  "ok": true,
  "checked": "skygrid-power-mesh-telemetry",
  "node_id": "skygrid-node-kfalls-001",
  "mode": "grid_connected",
  "emergency_ready": true
}
```

## Review note

The branch includes extra review-marker docs because this was pushed directly from the live concept review. Reviewers can squash/trim docs before merge if desired; the core artifacts are the fixture, schema, validator, review checklist, and route-hold safety boundary.