### PR TITLE
Add Aura Shield iOS blocker review scaffold

### DIFF
--- a/ios/AuraShield/AuraShieldApp.swift
+++ b/ios/AuraShield/AuraShieldApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AuraShieldApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/AuraShield/AuraShieldNumberStore.swift
+++ b/ios/AuraShield/AuraShieldNumberStore.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+final class AuraShieldNumberStore {
+    static let suiteName = "group.net.skygrid.aurashield"
+    static let numbersKey = "managedNumbers"
+
+    static var sharedDefaults: UserDefaults? {
+        UserDefaults(suiteName: suiteName)
+    }
+
+    static func saveNumbers(_ numbers: [String]) {
+        let cleaned = numbers
+            .map { $0.filter(\.isNumber) }
+            .filter { !$0.isEmpty }
+        sharedDefaults?.set(cleaned, forKey: numbersKey)
+    }
+
+    static func loadNumbers() -> [String] {
+        sharedDefaults?.stringArray(forKey: numbersKey) ?? []
+    }
+}

--- a/ios/AuraShield/ContentView.swift
+++ b/ios/AuraShield/ContentView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var number = ""
+    @State private var managedNumbers: [String] = []
+    @State private var statusMessage = "Add a number, then enable the iOS extension in Settings."
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                Text("Aura Shield")
+                    .font(.largeTitle.bold())
+
+                Text("Local call and message protection manager for known unwanted contact sources.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                TextField("Phone number", text: $number)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.phonePad)
+
+                Button("Add Number") {
+                    addNumber()
+                }
+                .buttonStyle(.borderedProminent)
+
+                Text(statusMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                List(managedNumbers, id: \.self) { item in
+                    Text(item)
+                }
+            }
+            .padding()
+            .navigationTitle("Aura Shield")
+            .onAppear {
+                managedNumbers = AuraShieldNumberStore.loadNumbers()
+            }
+        }
+    }
+
+    private func addNumber() {
+        let cleaned = number.filter(\.isNumber)
+        guard !cleaned.isEmpty else {
+            statusMessage = "Enter a valid phone number first."
+            return
+        }
+
+        if !managedNumbers.contains(cleaned) {
+            managedNumbers.append(cleaned)
+            managedNumbers.sort()
+            AuraShieldNumberStore.saveNumbers(managedNumbers)
+        }
+
+        number = ""
+        statusMessage = "Saved locally. Reload the Call Directory extension after wiring the target."
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/AuraShield/README.md
+++ b/ios/AuraShield/README.md
@@ -1,0 +1,34 @@
+# Aura Shield iOS Review Scaffold
+
+Aura Shield is a Swift/iOS starter module for managing a local list of unwanted contact sources and wiring that list into Apple's supported Call Directory flow.
+
+## Scope
+
+- SwiftUI starter app
+- Shared App Group storage scaffold
+- Call Directory Extension scaffold
+- Local-only storage by default
+- No cloud sync and no automatic outbound responses
+
+## Xcode setup
+
+1. Create or open an iOS app target named `AuraShield`.
+2. Add these source files to the app target:
+   - `AuraShieldApp.swift`
+   - `ContentView.swift`
+   - `AuraShieldNumberStore.swift`
+3. Add a Call Directory Extension target named `AuraShieldCallDirectoryExtension`.
+4. Add `AuraShieldCallDirectoryExtension/CallDirectoryHandler.swift` to the extension target.
+5. Add App Groups capability to both targets:
+   - `group.net.skygrid.aurashield`
+6. Enable the extension on device:
+   - Settings -> Phone -> Call Blocking & Identification -> Aura Shield
+
+## Review notes
+
+This PR intentionally keeps the extension handler as a scaffold. The next review step is to add the final CallKit load/reload implementation once the Xcode bundle identifiers and entitlements are confirmed.
+
+Suggested bundle identifiers:
+
+- App: `net.skygrid.AuraShield`
+- Extension: `net.skygrid.AuraShield.CallDirectory`

--- a/ios/AuraShieldCallDirectoryExtension/CallDirectoryHandler.swift
+++ b/ios/AuraShieldCallDirectoryExtension/CallDirectoryHandler.swift
@@ -1,0 +1,24 @@
+import Foundation
+import CallKit
+
+final class CallDirectoryHandler: CXCallDirectoryProvider {
+    override func beginRequest(with context: CXCallDirectoryExtensionContext) {
+        context.delegate = self
+
+        // Review scaffold:
+        // Wire this target to the shared App Group below, then convert saved strings
+        // into CXCallDirectoryPhoneNumber values and feed them to the context in
+        // strictly increasing numeric order.
+        //
+        // App Group: group.net.skygrid.aurashield
+        // Store key: managedNumbers
+
+        context.completeRequest()
+    }
+}
+
+extension CallDirectoryHandler: CXCallDirectoryExtensionContextDelegate {
+    func requestFailed(for extensionContext: CXCallDirectoryExtensionContext, withError error: Error) {
+        print("Aura Shield Call Directory request failed: \(error.localizedDescription)")
+    }
+}


### PR DESCRIPTION
## Summary

Adds an Aura Shield Swift/iOS starter scaffold for a local unwanted-contact protection workflow:

- SwiftUI app entry point and starter UI
- local shared App Group number store
- Call Directory Extension scaffold
- README with Xcode target, App Group, and device enablement steps

## Notes

The Call Directory handler is intentionally left as a review scaffold until bundle identifiers and entitlements are confirmed in Xcode. This avoids wiring production behavior before review.

## Suggested next step

Confirm the app and extension bundle identifiers, then wire the final CallKit reload/load implementation in a follow-up commit.