### PR TITLE
fix security IOC JSON BOM parsing

### DIFF
--- a/scripts/check-iocs.mjs
+++ b/scripts/check-iocs.mjs
@@ -10,7 +10,12 @@ if (!fs.existsSync(iocPath)) {
   process.exit(2);
 }
 
-const iocs = JSON.parse(fs.readFileSync(iocPath, "utf8"));
+function readJson(filePath) {
+  const raw = fs.readFileSync(filePath, "utf8").replace(/^\uFEFF/, "");
+  return JSON.parse(raw);
+}
+
+const iocs = readJson(iocPath);
 
 const terms = [
   ...(iocs.domains || []),


### PR DESCRIPTION
## Summary
- Adds a small `readJson()` helper for the IOC vault file.
- Strips a leading UTF-8 BOM before `JSON.parse()`.
- Keeps the existing IOC allowlist and scan behavior unchanged.

## Why
The `security:ioc-check` workflow failed on Node.js v24.18.0 because the IOC JSON file starts with an invisible UTF-8 BOM before `{`, causing `JSON.parse()` to throw `Unexpected token '﻿'`.

## Validation
Expected check:
```bash
npm run security:ioc-check
```

This should restore the IOC guard without weakening the security scan.