### PR TITLE
Add read-only receipt checker routes

### DIFF
--- a/api/receipt/check.js
+++ b/api/receipt/check.js
@@ -1,0 +1,43 @@
+function isReceiptId(value) {
+  return typeof value === "string" && /^0x[a-fA-F0-9]{64}$/.test(value);
+}
+
+export default async function handler(req, res) {
+  res.setHeader("Cache-Control", "no-store");
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ ok: false, error: "method_not_allowed" });
+  }
+
+  let body = {};
+  try {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const raw = Buffer.concat(chunks).toString("utf8");
+    body = raw ? JSON.parse(raw) : {};
+  } catch {
+    return res.status(400).json({ ok: false, error: "invalid_json" });
+  }
+
+  const receiptId = String(body.receiptId || body.hash || "");
+
+  if (!isReceiptId(receiptId)) {
+    return res.status(400).json({
+      ok: false,
+      route: "/api/receipt/check",
+      error: "invalid_receipt_id",
+      message: "Expected a 0x-prefixed 32-byte receipt id.",
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    route: "/api/receipt/check",
+    status: "format_valid",
+    advisoryOnly: true,
+    receiptId,
+    timestamp: new Date().toISOString()
+  });
+}

--- a/api/receipt/manifest.js
+++ b/api/receipt/manifest.js
@@ -1,0 +1,35 @@
+const PRODUCT = "SKYGRID Emergency Data On-Ramp";
+
+export default function handler(req, res) {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-SKYGRID-Product", PRODUCT);
+
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ ok: false, error: "method_not_allowed" });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    product: PRODUCT,
+    route: "/api/receipt/manifest",
+    mode: "read_only_receipt_check",
+    safety: {
+      custody: false,
+      signing: false,
+      broadcasting: false,
+      fundMovement: false,
+      advisoryOnly: true
+    },
+    supportedNetworks: [
+      { id: "ethereum-mainnet", env: "SKYGRID_ETHEREUM_RPC_URL", enabled: true },
+      { id: "base-mainnet", env: "SKYGRID_BASE_RPC_URL", enabled: true },
+      { id: "scroll-mainnet", env: "SKYGRID_SCROLL_RPC_URL", enabled: true }
+    ],
+    routes: {
+      readiness: "/api/receipt/readiness",
+      check: "/api/receipt/check"
+    },
+    timestamp: new Date().toISOString()
+  });
+}

--- a/scripts/check-iocs.mjs
+++ b/scripts/check-iocs.mjs
@@ -10,7 +10,13 @@ if (!fs.existsSync(iocPath)) {
   process.exit(2);
 }
 
-const iocs = JSON.parse(fs.readFileSync(iocPath, "utf8"));
+function readJsonFile(filePath) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const normalized = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  return JSON.parse(normalized);
+}
+
+const iocs = readJsonFile(iocPath);
 
 const terms = [
   ...(iocs.domains || []),


### PR DESCRIPTION
## Summary
- Adds a read-only receipt manifest endpoint.
- Adds a local receipt input checker endpoint for 0x-prefixed 32-byte ids.
- Keeps the feature advisory-only with no execution behavior.

## Safety
- No custody.
- No signing.
- No broadcasting.
- No fund movement.
- No secrets required.

## Routes
- `GET /api/receipt/manifest`
- `POST /api/receipt/check`