### PR TITLE
Add Cloudflare D1 persistence foundation

### DIFF
--- a/cloudflare/skygrid-edge-worker/schema/skygrid-orders.sql
+++ b/cloudflare/skygrid-edge-worker/schema/skygrid-orders.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS SkygridOrders (
+  Id TEXT PRIMARY KEY,
+  CustomerName TEXT NOT NULL,
+  OrderDate INTEGER NOT NULL,
+  ShippedDate INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_skygrid_orders_shipped_date
+ON SkygridOrders (ShippedDate DESC);
+
+INSERT OR REPLACE INTO SkygridOrders (Id, CustomerName, OrderDate, ShippedDate)
+VALUES
+  ('demo-001', 'SKYGRID Pilot', 1783630000, 1783630500),
+  ('demo-002', 'Edge Proof Partner', 1783630100, 1783630600);

--- a/cloudflare/skygrid-edge-worker/schema/skygrid-orders.sql
+++ b/cloudflare/skygrid-edge-worker/schema/skygrid-orders.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS SkygridOrders (
+﻿CREATE TABLE IF NOT EXISTS SkygridOrders (
   Id TEXT PRIMARY KEY,
   CustomerName TEXT NOT NULL,
   OrderDate INTEGER NOT NULL,
@@ -7,8 +7,3 @@ CREATE TABLE IF NOT EXISTS SkygridOrders (
 
 CREATE INDEX IF NOT EXISTS idx_skygrid_orders_shipped_date
 ON SkygridOrders (ShippedDate DESC);
-
-INSERT OR REPLACE INTO SkygridOrders (Id, CustomerName, OrderDate, ShippedDate)
-VALUES
-  ('demo-001', 'SKYGRID Pilot', 1783630000, 1783630500),
-  ('demo-002', 'Edge Proof Partner', 1783630100, 1783630600);

--- a/cloudflare/skygrid-edge-worker/wrangler.toml
+++ b/cloudflare/skygrid-edge-worker/wrangler.toml
@@ -5,3 +5,8 @@ workers_dev = true
 
 [vars]
 SKYGRID_ORIGIN = "https://aurcore.skygrid-protocol.net"
+
+[[d1_databases]]
+binding = "MY_DB"
+database_name = "skygrid-edge-proof-db"
+database_id = "c8412b71-35f3-42b2-bbd6-916cec7f67fd"


### PR DESCRIPTION
## Summary

Adds the Cloudflare D1 database binding and initial orders schema for the SKYGRID Emergency Data On-Ramp edge worker.

## Changes

- Adds the MY_DB D1 binding
- Adds the initial skygrid_orders schema
- Keeps generated setup artifacts outside the commit
- Preserves the controlled-pilot posture

## Validation

- Reviewed the staged diff
- Checked the staged patch for whitespace errors
- Kept credentials and generated setup artifacts out of the commit