### PR TITLE
Harden SKYGRID runtime diagnostics and intake security

### DIFF
--- a/api/runtime.mjs
+++ b/api/runtime.mjs
@@ -1,235 +1,224 @@
-const PRODUCT = "SKYGRID Emergency Data On-Ramp";
-const VERSION = "2026-07-04-aura-sky-front-door";
-const CANONICAL_HOST = "aura-sky.skygrid-protocol.net";
-const CANONICAL_URL = `https://${CANONICAL_HOST}`;
+import { createHmac, timingSafeEqual } from "node:crypto";
 
-function now() {
-  return new Date().toISOString();
-}
+const PRODUCT = "SKYGRID Emergency Data On-Ramp";
+const VERSION = "2026-07-13-hardened-runtime";
+const CANONICAL_URL = "https://aura-sky.skygrid-protocol.net";
+const MAX_BODY_BYTES = Number(process.env.SKYGRID_MAX_BODY_BYTES || 65536);
+const SIGNATURE_TOLERANCE_SECONDS = Number(process.env.SKYGRID_SIGNATURE_TOLERANCE_SECONDS || 300);
+const REQUEST_TIMEOUT_MS = Number(process.env.SKYGRID_UPSTREAM_TIMEOUT_MS || 8000);
+
+const now = () => new Date().toISOString();
+const routeMap = () => ["/", "/health.json", "/dispatch", "/incidents", "/settings", "/highway", "/scenarios", "/rates", "/base", "/pay", "/dashboard/command-center", "/dashboard/validation-panel", "/dashboard/deployment-review", "/dashboard/receipts", "/api/health", "/api/status", "/api/skygrid/status", "/api/skygrid/intake", "/api/aura-core/decide", "/api/agent/signals", "/api/highway/status", "/api/highway/flasks", "/api/highway/postman", "/api/pay/quote?amount=25", "/api/autodrill/latest", "/api/build-pad/quote", "/api/node-lease/intake", "/api/pacific-heart/ingest", "/api/failover/status", "/api/panels/summary", "/api/stripe/device-link"];
 
 function getPath(req) {
   const host = req.headers.host || "localhost";
   const url = new URL(req.url || "/", `https://${host}`);
-  return { host: host.split(":")[0].toLowerCase(), url, path: url.pathname };
+  return { url, path: url.pathname };
 }
 
-function headers(res) {
+function setHeaders(res) {
   res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Content-Security-Policy", "default-src 'self'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
   res.setHeader("X-SKYGRID-Product", PRODUCT);
   res.setHeader("X-SKYGRID-Runtime", VERSION);
 }
 
 function json(res, status, payload) {
-  headers(res);
+  setHeaders(res);
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
   res.end(JSON.stringify(payload, null, 2));
 }
 
 function html(res, status, title, body) {
-  headers(res);
+  setHeaders(res);
   res.statusCode = status;
   res.setHeader("Content-Type", "text/html; charset=utf-8");
-  res.end(`<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><link rel="canonical" href="${CANONICAL_URL}/"/><title>${title}</title><style>:root{color-scheme:dark}*{box-sizing:border-box}body{margin:0;font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:radial-gradient(circle at top left,#172554,#07101f 42%,#050816);color:#edf6ff}main{max-width:1120px;margin:0 auto;padding:42px 18px}.card{border:1px solid rgba(125,211,252,.3);border-radius:28px;padding:30px;background:linear-gradient(135deg,rgba(14,30,58,.94),rgba(43,26,72,.76));box-shadow:0 24px 80px rgba(0,0,0,.35)}h1{font-size:clamp(2.1rem,7vw,4.8rem);line-height:.96;letter-spacing:-.05em;margin:.2rem 0 1rem}p{line-height:1.65;color:#dbeafe}.badge{display:inline-block;border:1px solid rgba(255,255,255,.22);border-radius:999px;padding:.35rem .7rem;color:#f0abfc}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;margin-top:20px}.tile{border:1px solid rgba(255,255,255,.14);border-radius:18px;padding:17px;background:rgba(255,255,255,.055)}.tile strong{display:block;color:#fff;margin-bottom:.3rem}a{color:#67e8f9}code{background:rgba(255,255,255,.09);padding:.15rem .35rem;border-radius:.4rem}nav{display:flex;gap:10px;flex-wrap:wrap;margin:20px 0 8px}nav a,.button{border:1px solid rgba(255,255,255,.16);border-radius:999px;padding:10px 14px;text-decoration:none;background:rgba(255,255,255,.06);color:#cffafe;display:inline-block}.button.primary{background:rgba(34,211,238,.18);border-color:rgba(103,232,249,.44)}.notice{border-left:4px solid #f59e0b;padding:12px 14px;background:rgba(245,158,11,.11);border-radius:12px;margin-top:20px}.small{font-size:.94rem;color:#bdd7ee}</style></head><body><main><section class="card">${body}</section></main></body></html>`);
-}
-
-function routeMap() {
-  return [
-    "/", "/health.json", "/dispatch", "/incidents", "/settings", "/highway", "/scenarios", "/rates", "/base", "/pay",
-    "/dashboard/command-center", "/dashboard/validation-panel", "/dashboard/deployment-review", "/dashboard/receipts",
-    "/api/skygrid/status", "/api/skygrid/intake", "/api/aura-core/decide", "/api/agent/signals", "/api/highway/status",
-    "/api/highway/flasks", "/api/highway/postman", "/api/pay/quote?amount=25", "/api/autodrill/latest",
-    "/api/build-pad/quote", "/api/node-lease/intake", "/api/failover/status", "/api/panels/summary", "/api/stripe/device-link"
-  ];
-}
-
-function nav() {
-  return `<nav><a href="/">Front Page</a><a href="/dashboard/command-center">Command Center</a><a href="/dashboard/validation-panel">Validation</a><a href="/dashboard/deployment-review">Deployment Review</a><a href="/dashboard/receipts">Receipts</a><a href="/dispatch">Dispatch</a><a href="/health.json">Health</a></nav>`;
+  res.end(`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="canonical" href="${CANONICAL_URL}/"><title>${title}</title><style>:root{color-scheme:dark}body{margin:0;font-family:system-ui;background:#07101f;color:#edf6ff}main{max-width:1040px;margin:auto;padding:42px 20px}.card{border:1px solid #31506f;border-radius:24px;padding:28px;background:#0e1e3a}a{color:#67e8f9}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}.tile{border:1px solid #31506f;border-radius:16px;padding:16px}code{background:#172554;padding:.15rem .35rem;border-radius:.35rem}</style></head><body><main><section class="card">${body}</section></main></body></html>`);
 }
 
 function configured() {
   return {
+    ingestAuth: Boolean(process.env.SKYGRID_INGEST_SECRET),
     awsStatusUrl: Boolean(process.env.SKYGRID_AWS_STATUS_URL),
     awsIntakeUrl: Boolean(process.env.SKYGRID_AWS_INTAKE_URL),
+    lambdaRouterUrl: Boolean(process.env.SKYGRID_LAMBDA_ROUTER_URL),
     emergencyCallId: Boolean(process.env.SKYGRID_EMERGENCY_CALL_ID),
     partnershipCode: Boolean(process.env.SKYGRID_PARTNERSHIP_CODE),
-    lambdaRouterUrl: Boolean(process.env.SKYGRID_LAMBDA_ROUTER_URL),
-    s3Bucket: Boolean(process.env.SKYGRID_S3_BUCKET)
+    proofArtifactUrl: Boolean(process.env.SKYGRID_PROOF_ARTIFACT_URL)
   };
 }
 
-function launchLadder() {
-  return [
-    { step: 1, id: "auto_drill_proof", label: "Auto-drill proof", status: "route_added" },
-    { step: 2, id: "build_pad_quote", label: "Build-pad quote", status: "route_added_quote_only" },
-    { step: 3, id: "node_lease_intake", label: "Node lease intake", status: "route_added_no_activation" },
-    { step: 4, id: "dashboard", label: "Dashboard", status: "route_added" },
-    { step: 5, id: "aws_persistence", label: "AWS persistence", status: "env_gated" },
-    { step: 6, id: "partner_pilot", label: "Partner pilot", status: "package_ready_for_review" },
-    { step: 7, id: "manual_failover", label: "Manual failover", status: "operator_gate_required" }
-  ];
-}
-
-function safetyNotice() {
-  return `<div class="notice"><strong>Controlled pilot:</strong> this public runtime is for explanation, route proof, and operator review. Production activation stays gated.</div>`;
-}
-
-function landing(res) {
-  return html(res, 200, "Aura Sky | SKYGRID", `
-    <span class="badge">Public front page</span>
-    <h1>Emergency data should still have a trusted path forward.</h1>
-    <p><strong>${PRODUCT}</strong> is the public concept and proof hub for resilient outage, responder, system-health, and continuity data routing.</p>
-    <p>This is the visitor-facing landing page. All other SKYGRID links should either point here, redirect here, or be linked from here.</p>
-    <p><a class="button primary" href="/dashboard/command-center">Open Command Center</a> <a class="button" href="/health.json">Check Health</a></p>
-    ${nav()}
-    <div class="grid">
-      <div class="tile"><strong>What it is</strong>A secure entry point where critical continuity data can be validated, logged, routed, proved, and surfaced.</div>
-      <div class="tile"><strong>Proof lane</strong><a href="/api/highway/postman">Postman proof</a><br><a href="/api/autodrill/latest">Auto-drill status</a></div>
-      <div class="tile"><strong>Dashboards</strong><a href="/dashboard/command-center">Command Center</a><br><a href="/dashboard/validation-panel">Validation Panel</a><br><a href="/dashboard/receipts">Receipts</a></div>
-      <div class="tile"><strong>Status</strong><a href="/api/skygrid/status">SKYGRID status</a><br><a href="/api/failover/status">Failover gate</a></div>
-      <div class="tile"><strong>Build pad</strong><code>POST /api/build-pad/quote</code><br><span class="small">Quote-only review route.</span></div>
-      <div class="tile"><strong>Node lease</strong><code>POST /api/node-lease/intake</code><br><span class="small">Intake-only readiness route.</span></div>
-      <div class="tile"><strong>Dispatch</strong><a href="/dispatch">Dispatch overview</a><br><a href="/highway">Emergency highway</a></div>
-      <div class="tile"><strong>Canonical URL</strong><code>${CANONICAL_URL}</code></div>
-    </div>
-    ${safetyNotice()}
-  `);
-}
-
-function healthPayload(path) {
-  return {
-    ok: true,
-    product: PRODUCT,
-    skygrid: PRODUCT,
-    canonical_front_page: CANONICAL_URL,
-    runtime: "vercel-aura-core",
-    version: VERSION,
-    mode: "controlled-pilot",
-    sentinel: "fail_closed",
-    route: path,
-    configured: configured(),
-    launch_ladder: launchLadder(),
-    routes: routeMap(),
-    timestamp: now()
-  };
-}
-
-async function readBody(req) {
+async function readJsonBody(req) {
+  const contentType = String(req.headers["content-type"] || "").split(";")[0].trim().toLowerCase();
+  if (contentType !== "application/json") {
+    const error = new Error("content_type_must_be_application_json");
+    error.statusCode = 415;
+    throw error;
+  }
   const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > MAX_BODY_BYTES) {
+      const error = new Error("payload_too_large");
+      error.statusCode = 413;
+      throw error;
+    }
+    chunks.push(chunk);
+  }
   const raw = Buffer.concat(chunks).toString("utf8");
-  if (!raw) return {};
-  try { return JSON.parse(raw); } catch { return { raw }; }
+  if (!raw) return { raw: "", body: {} };
+  try {
+    const body = JSON.parse(raw);
+    if (!body || Array.isArray(body) || typeof body !== "object") throw new Error("invalid_json_object");
+    return { raw, body };
+  } catch {
+    const error = new Error("invalid_json");
+    error.statusCode = 400;
+    throw error;
+  }
+}
+
+function verifySignedRequest(req, raw) {
+  const secret = process.env.SKYGRID_INGEST_SECRET;
+  if (!secret) return { ok: false, status: 503, error: "ingest_auth_not_configured" };
+  const timestamp = String(req.headers["x-skygrid-timestamp"] || "");
+  const signature = String(req.headers["x-skygrid-signature"] || "").replace(/^sha256=/, "");
+  const epoch = Number(timestamp);
+  if (!Number.isFinite(epoch) || Math.abs(Date.now() / 1000 - epoch) > SIGNATURE_TOLERANCE_SECONDS) {
+    return { ok: false, status: 401, error: "stale_or_invalid_timestamp" };
+  }
+  const expected = createHmac("sha256", secret).update(`${timestamp}.${raw}`).digest("hex");
+  const left = Buffer.from(signature, "hex");
+  const right = Buffer.from(expected, "hex");
+  if (left.length !== right.length || !timingSafeEqual(left, right)) return { ok: false, status: 401, error: "invalid_signature" };
+  return { ok: true };
+}
+
+function requireFields(body, fields) {
+  return fields.filter((key) => body[key] === undefined || body[key] === null || body[key] === "");
+}
+
+function sanitizeEvent(body, path) {
+  return {
+    eventId: `skygrid_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    receivedAt: now(),
+    route: path,
+    source: String(body.source || "unknown").slice(0, 120),
+    type: String(body.type || body.need || "system-health").slice(0, 120),
+    severity: String(body.severity || "normal").slice(0, 40),
+    region: body.region ? String(body.region).slice(0, 120) : undefined
+  };
+}
+
+async function fetchJson(url, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    const text = await response.text();
+    let body;
+    try { body = JSON.parse(text); } catch { body = { raw: text.slice(0, 2048) }; }
+    return { ok: response.ok, status: response.status, body };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function healthPayload(path) {
+  const cfg = configured();
+  let aws = { checked: false, ok: false, reason: "not_configured" };
+  if (cfg.awsStatusUrl && cfg.emergencyCallId && cfg.partnershipCode) {
+    try {
+      const result = await fetchJson(process.env.SKYGRID_AWS_STATUS_URL, { headers: { "X-Emergency-Call-ID": process.env.SKYGRID_EMERGENCY_CALL_ID, "X-Partnership-Code": process.env.SKYGRID_PARTNERSHIP_CODE } });
+      aws = { checked: true, ok: result.ok, status: result.status };
+    } catch (error) {
+      aws = { checked: true, ok: false, error: error.name === "AbortError" ? "timeout" : "upstream_error" };
+    }
+  }
+  const ready = cfg.ingestAuth && aws.ok;
+  return { ok: true, process_healthy: true, ready, product: PRODUCT, version: VERSION, mode: "controlled-pilot", sentinel: "fail_closed", route: path, configured: cfg, dependencies: { aws }, routes: routeMap(), timestamp: now() };
+}
+
+function failoverStatus() {
+  const cfg = configured();
+  return { ok: true, product: PRODUCT, mode: "controlled_pilot", sentinel: "fail_closed", failover_state: "blocked", readiness: { ingest_auth_ready: cfg.ingestAuth, aws_persistence_ready: cfg.awsStatusUrl && cfg.awsIntakeUrl && cfg.emergencyCallId && cfg.partnershipCode, health_quorum_ready: false, rollback_ready: false, production_policy_ready: false }, prohibited_actions: ["automatic_wallet_signing", "automatic_transaction_broadcast", "private_data_movement", "device_activation", "production_failover_without_approval"], timestamp: now() };
 }
 
 function decision(body = {}) {
   const need = String(body.need || body.type || "system-health").toLowerCase();
   const severity = String(body.severity || "normal").toLowerCase();
-  const urgent = ["critical", "high", "sev1", "p1"].includes(severity) || need.includes("outage");
+  const urgent = ["critical", "high", "sev1", "p1"].includes(severity) || need.includes("outage") || need.includes("emergency");
   return { selected: urgent ? "lambda_router" : "advisory_response", reason: urgent ? "urgent_signal" : "safe_default", advisoryOnly: true };
 }
 
-function failoverStatus() {
-  return { ok: true, product: PRODUCT, canonical_front_page: CANONICAL_URL, mode: "controlled_pilot", sentinel: "fail_closed", failover_state: "blocked", manual_failover: "operator_gate_required", readiness: { github_manifest: true, postman_proof_lane: true, dashboard_routes: true, public_front_page: true, aws_persistence_ready: false }, timestamp: now() };
-}
-
-function panelSummary(path) {
-  return { ok: true, product: PRODUCT, canonical_front_page: CANONICAL_URL, route: path, mode: "controlled_pilot", sentinel: "fail_closed", status: { public_front_page: { ok: true, route: "/" }, health: { ok: true, route: "/health.json" }, postman: { ok: true, route: "/api/highway/postman" }, failover: { ok: true, state: "blocked" } }, routes: routeMap(), launch_ladder: launchLadder(), timestamp: now() };
-}
-
-function dashboard(res, path) {
-  const titles = {
-    "/dashboard/command-center": ["SKYGRID Command Center", "Public front-door, proof lane, dashboard, and operator review."],
-    "/dashboard/validation-panel": ["SKYGRID Validation Panel", "Manifest, Postman, runtime, and domain checks."],
-    "/dashboard/deployment-review": ["SKYGRID Deployment Review", "Vercel, route, and domain readiness review."],
-    "/dashboard/receipts": ["SKYGRID Receipts", "Proof receipts for route checks and deployment review."]
-  };
-  const [title, intro] = titles[path];
-  return html(res, 200, title, `<span class="badge">Dashboard</span><h1>${title}</h1><p>${intro}</p>${nav()}<div class="grid"><div class="tile"><strong>Canonical</strong><code>${CANONICAL_URL}</code></div><div class="tile"><strong>Health</strong><a href="/health.json">/health.json</a></div><div class="tile"><strong>Proof</strong><a href="/api/highway/postman">/api/highway/postman</a></div><div class="tile"><strong>Summary</strong><a href="/api/panels/summary">/api/panels/summary</a></div></div>${safetyNotice()}`);
+function landing(res) {
+  return html(res, 200, "Aura Sky | SKYGRID", `<h1>${PRODUCT}</h1><p>Controlled-pilot proof hub for resilient emergency, outage, responder, system-health, and continuity data routing.</p><div class="grid"><div class="tile"><a href="/health.json">Health</a></div><div class="tile"><a href="/api/failover/status">Failover gate</a></div><div class="tile"><a href="/api/autodrill/latest">Auto-drill evidence</a></div><div class="tile"><a href="/dashboard/command-center">Command Center</a></div></div><p><strong>Production activation remains blocked until authentication, persistence, quorum, rollback, and operator approval are verified.</strong></p>`);
 }
 
 function simplePage(res, title, intro) {
-  return html(res, 200, title, `<span class="badge">SKYGRID</span><h1>${title}</h1><p>${intro}</p>${nav()}${safetyNotice()}`);
+  return html(res, 200, title, `<h1>${title}</h1><p>${intro}</p><p><a href="/">Home</a> · <a href="/health.json">Health</a> · <a href="/api/failover/status">Failover</a></p>`);
 }
 
 export default async function handler(req, res) {
   const { path, url } = getPath(req);
+  try {
+    if (req.method === "GET" && path === "/") return landing(res);
+    if (req.method === "GET" && ["/health.json", "/api/health", "/api/status", "/api/skygrid/status", "/api/highway/status"].includes(path)) {
+      const payload = await healthPayload(path);
+      return json(res, 200, payload);
+    }
+    if (req.method === "GET" && path === "/api/failover/status") return json(res, 200, failoverStatus());
+    if (req.method === "GET" && path === "/api/panels/summary") return json(res, 200, { ok: true, product: PRODUCT, health: "/health.json", failover: "/api/failover/status", proof: "/api/autodrill/latest", timestamp: now() });
+    if (req.method === "GET" && path === "/api/autodrill/latest") {
+      const cfg = configured();
+      return json(res, cfg.proofArtifactUrl ? 200 : 424, { ok: cfg.proofArtifactUrl, product: PRODUCT, proof_owner: "postman", result: cfg.proofArtifactUrl ? "artifact_configured" : "proof_artifact_missing", artifact_url_configured: cfg.proofArtifactUrl, synthetic_pass_removed: true, timestamp: now() });
+    }
+    if (req.method === "GET" && path === "/api/highway/postman") return json(res, 200, { ok: true, product: PRODUCT, collection: "skygrid-autodrill.collection.json", evidence_route: "/api/autodrill/latest", timestamp: now() });
+    if (req.method === "GET" && path === "/api/highway/flasks") return json(res, 200, { ok: true, product: PRODUCT, flasks: [{ id: "aws", status: configured().awsStatusUrl ? "configured" : "not_configured" }, { id: "vercel", status: "public_bridge" }, { id: "postman", status: configured().proofArtifactUrl ? "artifact_configured" : "artifact_missing" }], timestamp: now() });
 
-  if (req.method === "GET" && path === "/") return landing(res);
-  if (req.method === "GET" && ["/dashboard/command-center", "/dashboard/validation-panel", "/dashboard/deployment-review", "/dashboard/receipts"].includes(path)) return dashboard(res, path);
-  if (req.method === "GET" && ["/health.json", "/api/health", "/api/status", "/api/skygrid/status", "/api/highway/status"].includes(path)) {
-    return json(res, 200, healthPayload(path));
-  }
-  if (req.method === "GET" && path === "/api/failover/status") return json(res, 200, failoverStatus());
-  if (req.method === "GET" && path === "/api/panels/summary") return json(res, 200, panelSummary(path));
-  if (req.method === "GET" && path === "/api/autodrill/latest") return json(res, 200, { ok: true, product: PRODUCT, route: path, proof_owner: "postman", result: "pass_with_warnings", checks: ["front_page", "health", "status", "dashboard", "failover"], timestamp: now() });
-  if (req.method === "GET" && path === "/api/highway/postman") return json(res, 200, { ok: true, product: PRODUCT, collection: "skygrid-autodrill.collection.json", checks: ["front-page", "status", "health", "intake", "dashboard", "failover-status"], timestamp: now() });
-  if (req.method === "GET" && path === "/api/highway/flasks") return json(res, 200, { ok: true, product: PRODUCT, flasks: [{ id: "aws", status: "protected" }, { id: "vercel", status: "public-bridge" }, { id: "postman", status: "proof-runner" }], timestamp: now() });
-
-  if (req.method === "POST" && path === "/api/build-pad/quote") {
-    const body = await readBody(req);
-    const amount = Number(body.amount || body.monthlySupportUsd || 250);
-    return json(res, 200, { ok: true, product: PRODUCT, route: path, mode: "quote_only_review_required", quote_id: `buildpad_${Date.now()}`, noPaymentExecuted: true, amount, timestamp: now() });
-  }
-
-  if (req.method === "POST" && path === "/api/node-lease/intake") {
-    const body = await readBody(req);
-    return json(res, 202, { accepted: true, product: PRODUCT, route: path, mode: "intake_only", intake_id: `lease_${Date.now()}`, region: body.region || "unspecified", timestamp: now() });
-  }
-
-  if (req.method === "POST" && path === "/api/pacific-heart/ingest") {
-    const body = await readBody(req);
-    const required = ["eventId", "source", "patientRef", "incidentType", "severity"];
-    const missing = required.filter((key) => !body[key]);
-
-    if (missing.length > 0) {
-      return json(res, 400, {
-        ok: false,
-        status: "invalid_payload",
-        product: PRODUCT,
-        route: path,
-        missing,
-        timestamp: now()
-      });
+    if (req.method === "GET" && path === "/api/pay/quote") {
+      const amount = Number(url.searchParams.get("amount") || "0");
+      if (!Number.isFinite(amount) || amount < 0 || amount > 1000000) return json(res, 400, { ok: false, error: "invalid_amount", timestamp: now() });
+      return json(res, 200, { ok: true, quoteOnly: true, noPaymentExecuted: true, amount, currency: "USD", timestamp: now() });
     }
 
-    const severity = String(body.severity || "normal").toLowerCase();
-    const urgent = ["critical", "high", "sev1", "p1"].includes(severity);
+    const protectedPostRoutes = ["/api/skygrid/intake", "/intake", "/api/agent/signals", "/api/node-lease/intake", "/api/pacific-heart/ingest"];
+    if (req.method === "POST" && [...protectedPostRoutes, "/api/aura-core/decide", "/api/build-pad/quote"].includes(path)) {
+      const { raw, body } = await readJsonBody(req);
+      if (protectedPostRoutes.includes(path)) {
+        const auth = verifySignedRequest(req, raw);
+        if (!auth.ok) return json(res, auth.status, { ok: false, error: auth.error, timestamp: now() });
+      }
+      if (path === "/api/build-pad/quote") {
+        const amount = Number(body.amount ?? body.monthlySupportUsd ?? 250);
+        if (!Number.isFinite(amount) || amount < 0 || amount > 1000000) return json(res, 400, { ok: false, error: "invalid_amount", timestamp: now() });
+        return json(res, 200, { ok: true, mode: "quote_only_review_required", quote_id: `buildpad_${Date.now()}`, noPaymentExecuted: true, amount, timestamp: now() });
+      }
+      if (path === "/api/aura-core/decide") return json(res, 200, { ok: true, advisoryOnly: true, decision: decision(body), timestamp: now() });
+      if (path === "/api/pacific-heart/ingest") {
+        const missing = requireFields(body, ["eventId", "source", "patientRef", "incidentType", "severity"]);
+        if (missing.length) return json(res, 400, { ok: false, error: "invalid_payload", missing, timestamp: now() });
+        return json(res, 202, { ok: true, status: "accepted", mode: "controlled_pilot_sandbox", noDispatch: true, noDiagnosis: true, receipt: { eventId: String(body.eventId).slice(0, 160), priority: ["critical", "high", "sev1", "p1"].includes(String(body.severity).toLowerCase()) ? "urgent_review" : "standard_review" }, timestamp: now() });
+      }
+      const event = sanitizeEvent(body, path);
+      return json(res, 202, { accepted: true, advisoryOnly: true, receipt: event, decision: decision(body), payloadStored: false, payloadEchoed: false });
+    }
 
-    return json(res, 202, {
-      ok: true,
-      status: "accepted",
-      product: PRODUCT,
-      route: path,
-      mode: "controlled_pilot_sandbox",
-      noDispatch: true,
-      noDiagnosis: true,
-      eventId: body.eventId,
-      handoff: {
-        humanReviewRequired: true,
-        priority: urgent ? "urgent_review" : "standard_review"
-      },
-      timestamp: now()
-    });
+    if (req.method === "GET" && ["/dispatch", "/incidents", "/settings", "/highway", "/dashboard/command-center", "/dashboard/validation-panel", "/dashboard/deployment-review", "/dashboard/receipts"].includes(path)) return simplePage(res, `SKYGRID ${path.split("/").filter(Boolean).pop().replaceAll("-", " ")}`, "Controlled-pilot route for status, proof, and operator review.");
+    if (req.method === "GET" && ["/scenarios", "/rates", "/base"].includes(path)) return json(res, 200, { ok: true, product: PRODUCT, route: path, mode: "demo", timestamp: now() });
+    if (req.method === "GET" && path === "/pay") return simplePage(res, "SKYGRID Support Demo", "Quote-only support route. No payment is executed.");
+    if (req.method === "GET" && path === "/api/stripe/device-link") return json(res, 501, { ok: false, reason: "legacy_prototype_route_only", timestamp: now() });
+    return json(res, 404, { ok: false, error: "route_not_found", path, routes: routeMap(), timestamp: now() });
+  } catch (error) {
+    const status = Number(error.statusCode || 500);
+    return json(res, status, { ok: false, error: status >= 500 ? "internal_error" : error.message, timestamp: now() });
   }
-
-  if (req.method === "POST" && ["/api/skygrid/intake", "/intake", "/api/aura-core/decide", "/api/agent/signals"].includes(path)) {
-    const body = await readBody(req);
-    const event = { eventId: `skygrid_${Date.now()}`, receivedAt: now(), product: PRODUCT, skygrid: PRODUCT, route: path, source: body.source || "postman-autodrill", type: body.type || body.need || "system-health", decision: decision(body), payload: body };
-    return json(res, 202, { accepted: true, advisoryOnly: true, event });
-  }
-
-  if (req.method === "GET" && path === "/dispatch") return simplePage(res, "SKYGRID Dispatch", "Controlled-pilot dispatch page for status, routing review, and proof logging.");
-  if (req.method === "GET" && path === "/incidents") return simplePage(res, "SKYGRID Incidents", "Incident review page for demo triggers, recommendations, decisions, and JSON records.");
-  if (req.method === "GET" && path === "/settings") return simplePage(res, "SKYGRID Settings", "Configuration reference for thresholds, route checks, and agent signals.");
-  if (req.method === "GET" && path === "/highway") return simplePage(res, "SKYGRID Emergency Highway", "Public proof lane for status, route map, and auto-drill validation.");
-  if (req.method === "GET" && ["/scenarios", "/rates", "/base"].includes(path)) return json(res, 200, { ok: true, product: PRODUCT, route: path, mode: "demo", timestamp: now() });
-  if (req.method === "GET" && path === "/pay") return simplePage(res, "SKYGRID Support Demo", "Quote-only support route. No payment is executed by this demo page.");
-  if (req.method === "GET" && path === "/api/pay/quote") {
-    const amount = Number(url.searchParams.get("amount") || "0");
-    return json(res, 200, { ok: true, product: PRODUCT, quoteOnly: true, noPaymentExecuted: true, amount, currency: "USD", timestamp: now() });
-  }
-  if (req.method === "GET" && path === "/api/stripe/device-link") return json(res, 501, { ok: false, product: PRODUCT, route: path, reason: "Legacy prototype route only.", timestamp: now() });
-
-  return json(res, 404, { ok: false, product: PRODUCT, error: "route_not_found", path, routes: routeMap(), timestamp: now() });
 }
+
+export const __test = { readJsonBody, verifySignedRequest, sanitizeEvent, decision, healthPayload };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "xmcp:build": "node tools/xmcp/index.mjs build --vercel",
     "skygrid:verify": "node scripts/verify-skygrid-routes.mjs",
     "skygrid:test:routing": "node scripts/test-skygrid-routing-success.mjs",
+    "test:runtime-security": "node scripts/test-runtime-security.mjs",
+    "test:security": "node scripts/test-runtime-security.mjs && node scripts/check-iocs.mjs",
     "aura:selection:watch": "node scripts/aura-core-ai-selection-watch.mjs",
     "mcp:check": "node scripts/check-mcp-sdk.mjs",
     "emergency:gate": "node scripts/skygrid-emergency-gate.mjs",

--- a/scripts/test-runtime-security.mjs
+++ b/scripts/test-runtime-security.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { createHmac } from "node:crypto";
+import handler from "../api/runtime.mjs";
+
+function request(method, url, body = "", headers = {}) {
+  const req = Readable.from(body ? [Buffer.from(body)] : []);
+  req.method = method;
+  req.url = url;
+  req.headers = { host: "localhost", ...headers };
+  return req;
+}
+
+function response() {
+  return {
+    headers: {},
+    setHeader(key, value) { this.headers[key] = value; },
+    end(value) { this.body = value; }
+  };
+}
+
+async function run(req) {
+  const res = response();
+  await handler(req, res);
+  return { status: res.statusCode, headers: res.headers, body: JSON.parse(res.body) };
+}
+
+process.env.SKYGRID_INGEST_SECRET = "test-secret";
+const raw = JSON.stringify({ source: "test", type: "outage", secretNote: "must-not-echo" });
+const timestamp = String(Math.floor(Date.now() / 1000));
+const signature = createHmac("sha256", process.env.SKYGRID_INGEST_SECRET).update(`${timestamp}.${raw}`).digest("hex");
+
+const unsigned = await run(request("POST", "/api/skygrid/intake", raw, { "content-type": "application/json" }));
+assert.equal(unsigned.status, 401);
+
+const signed = await run(request("POST", "/api/skygrid/intake", raw, {
+  "content-type": "application/json",
+  "x-skygrid-timestamp": timestamp,
+  "x-skygrid-signature": `sha256=${signature}`
+}));
+assert.equal(signed.status, 202);
+assert.equal(signed.body.payloadEchoed, false);
+assert.equal(JSON.stringify(signed.body).includes("must-not-echo"), false);
+
+const badType = await run(request("POST", "/api/build-pad/quote", "{}", { "content-type": "text/plain" }));
+assert.equal(badType.status, 415);
+
+const proof = await run(request("GET", "/api/autodrill/latest"));
+assert.equal(proof.status, 424);
+assert.equal(proof.body.synthetic_pass_removed, true);
+
+const health = await run(request("GET", "/health.json"));
+assert.equal(health.status, 200);
+assert.equal(health.body.process_healthy, true);
+assert.equal(typeof health.body.ready, "boolean");
+assert.equal(health.headers["X-Content-Type-Options"], "nosniff");
+
+console.log("runtime security tests passed");

--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,8 @@
     { "source": "/dashboard/validation-panel", "destination": "/api/runtime" },
     { "source": "/dashboard/deployment-review", "destination": "/api/runtime" },
     { "source": "/dashboard/receipts", "destination": "/api/runtime" },
+    { "source": "/api/health", "destination": "/api/runtime" },
+    { "source": "/api/status", "destination": "/api/runtime" },
     { "source": "/api/skygrid/status", "destination": "/api/runtime" },
     { "source": "/api/skygrid/intake", "destination": "/api/runtime" },
     { "source": "/api/aura-core/decide", "destination": "/api/runtime" },
@@ -38,6 +40,7 @@
     { "source": "/api/autodrill/latest", "destination": "/api/runtime" },
     { "source": "/api/build-pad/quote", "destination": "/api/runtime" },
     { "source": "/api/node-lease/intake", "destination": "/api/runtime" },
+    { "source": "/api/pacific-heart/ingest", "destination": "/api/runtime" },
     { "source": "/api/failover/status", "destination": "/api/runtime" },
     { "source": "/api/panels/summary", "destination": "/api/runtime" }
   ]


### PR DESCRIPTION
## What changed

- Require HMAC-signed requests for protected SKYGRID intake routes.
- Enforce `application/json`, a 64 KiB default payload ceiling, timestamp freshness, and constant-time signature checks.
- Stop echoing submitted payloads and return sanitized receipts instead.
- Add upstream health timeouts and separate process health from operational readiness.
- Remove the synthetic auto-drill pass; the proof endpoint now fails with `424` until a real artifact is configured.
- Add browser/API security headers.
- Validate quote amounts and Pacific Heart required fields.
- Add regression tests for unsigned intake, payload redaction, content type enforcement, proof status, health semantics, and security headers.
- Add missing Vercel rewrites for health/status and Pacific Heart intake.

## Why

The v0.1.0 runtime was safe in its fail-closed production posture, but public POST routes accepted arbitrary JSON without authentication, size limits, or strict evidence semantics. Health and auto-drill responses could also be mistaken for verified downstream readiness.

## Configuration required before deployment

Set `SKYGRID_INGEST_SECRET` in Vercel and in each authorized sender. Send:

- `X-SKYGRID-Timestamp`: current Unix time in seconds
- `X-SKYGRID-Signature`: `sha256=<HMAC_SHA256(secret, timestamp + "." + raw_json_body)>`

Optional controls:

- `SKYGRID_MAX_BODY_BYTES` (default `65536`)
- `SKYGRID_SIGNATURE_TOLERANCE_SECONDS` (default `300`)
- `SKYGRID_UPSTREAM_TIMEOUT_MS` (default `8000`)
- `SKYGRID_PROOF_ARTIFACT_URL` to mark real Postman/Newman evidence as configured

## Validation

- `node --check api/runtime.mjs`
- `node --check scripts/test-runtime-security.mjs`
- Security regression script added as `pnpm run test:runtime-security`

The branch remains fail-closed and does not enable production failover, wallet signing, transaction broadcasting, device activation, or private-data movement.