### PR TITLE
feat(pilot): add fail-closed evidence ledger intake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ wallet/veteran-status/server/**/*.key
 wallet/veteran-status/server/**/*.pem
 wallet/veteran-status/server/**/*.cer
 wallet/veteran-status/server/**/*.certSigningRequest
+cloudflare/skygrid-edge-worker/.tmp/

--- a/cloudflare/skygrid-edge-worker/schema/skygrid-pilot-events.sql
+++ b/cloudflare/skygrid-edge-worker/schema/skygrid-pilot-events.sql
@@ -1,0 +1,64 @@
+CREATE TABLE IF NOT EXISTS SkygridPilotEvents (
+  EventId TEXT NOT NULL PRIMARY KEY,
+  PartnerId TEXT NOT NULL,
+  CorrelationId TEXT NOT NULL,
+
+  ReceivedAt TEXT NOT NULL,
+  CreatedAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  RouteType TEXT NOT NULL,
+  RequestedRamp TEXT NOT NULL,
+  RequestedNode TEXT NOT NULL,
+
+  DecisionOk INTEGER NOT NULL
+    CHECK (DecisionOk IN (0, 1)),
+
+  HttpStatus INTEGER NOT NULL,
+  DecisionReason TEXT NOT NULL,
+
+  Mode TEXT NOT NULL
+    CHECK (Mode = 'controlled_pilot'),
+
+  Sentinel TEXT NOT NULL
+    CHECK (Sentinel = 'fail_closed'),
+
+  OwnerApproval INTEGER NOT NULL DEFAULT 0
+    CHECK (OwnerApproval IN (0, 1)),
+
+  EmergencyOperatorApproval INTEGER NOT NULL DEFAULT 0
+    CHECK (EmergencyOperatorApproval IN (0, 1)),
+
+  PayloadHash TEXT NOT NULL,
+  PayloadBytes INTEGER NOT NULL
+    CHECK (PayloadBytes >= 0),
+
+  ReceiptHash TEXT NOT NULL,
+
+  ProcessingMs INTEGER NOT NULL
+    CHECK (ProcessingMs >= 0),
+
+  AuraValidated INTEGER NOT NULL DEFAULT 0
+    CHECK (AuraValidated IN (0, 1)),
+
+  ReceiptVersion TEXT NOT NULL DEFAULT '1.0',
+
+  UNIQUE (PartnerId, CorrelationId),
+
+  CHECK (
+    (DecisionOk = 1 AND AuraValidated = 1)
+    OR
+    (DecisionOk = 0 AND AuraValidated = 0)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_pilot_events_received
+ON SkygridPilotEvents (ReceivedAt DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pilot_events_partner
+ON SkygridPilotEvents (PartnerId, ReceivedAt DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pilot_events_decision
+ON SkygridPilotEvents (DecisionOk, ReceivedAt DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pilot_events_reason
+ON SkygridPilotEvents (DecisionReason, ReceivedAt DESC);

--- a/cloudflare/skygrid-edge-worker/src/index.js
+++ b/cloudflare/skygrid-edge-worker/src/index.js
@@ -1,3 +1,4 @@
+import { handlePilotIntake } from "./pilot-intake.js";
 const REQUIRED_ROUTES = [
   "/",
   "/health.json",
@@ -23,6 +24,22 @@ export default {
     const origin =
       env.SKYGRID_ORIGIN || "https://aurcore.skygrid-protocol.net";
 
+    if (url.pathname === "/edge/intake") {
+      if (request.method !== "POST") {
+        return json(
+          {
+            ok: false,
+            system: "SKYGRID Emergency Data On-Ramp",
+            message: "POST is required for /edge/intake."
+          },
+          405
+        );
+      }
+
+      return handlePilotIntake(request, env, {
+        origin
+      });
+    }
     if (url.pathname === "/edge/health") {
       return json({
         ok: true,
@@ -143,7 +160,7 @@ export default {
         ok: false,
         system: "SKYGRID Emergency Data On-Ramp",
         message:
-          "Use /edge/health, /edge/d1/health, or /edge/proof for Cloudflare edge validation.",
+          "Use /edge/intake, /edge/health, /edge/d1/health, or /edge/proof.",
       },
       404
     );

--- a/cloudflare/skygrid-edge-worker/src/pilot-evidence.js
+++ b/cloudflare/skygrid-edge-worker/src/pilot-evidence.js
@@ -1,0 +1,283 @@
+const encoder = new TextEncoder();
+
+export const MAX_PILOT_PAYLOAD_BYTES = 16_384;
+
+export async function sha256Hex(value) {
+  const bytes =
+    value instanceof Uint8Array
+      ? value
+      : encoder.encode(String(value));
+
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function constantTimeEqual(leftValue, rightValue) {
+  const left = encoder.encode(String(leftValue ?? ""));
+  const right = encoder.encode(String(rightValue ?? ""));
+
+  const maximumLength = Math.max(left.length, right.length);
+  let difference = left.length ^ right.length;
+
+  for (let index = 0; index < maximumLength; index += 1) {
+    difference |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+
+  return difference === 0;
+}
+
+export function authenticatePilot(request, env) {
+  const expectedKey = String(env.SKYGRID_PILOT_API_KEY ?? "");
+  const suppliedKey = String(
+    request.headers.get("x-skygrid-pilot-key") ?? ""
+  );
+
+  if (!expectedKey) {
+    return {
+      ok: false,
+      status: 503,
+      reason: "pilot_key_not_configured"
+    };
+  }
+
+  if (!suppliedKey) {
+    return {
+      ok: false,
+      status: 401,
+      reason: "pilot_key_required"
+    };
+  }
+
+  if (!constantTimeEqual(suppliedKey, expectedKey)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: "pilot_key_invalid"
+    };
+  }
+
+  const partnerId = String(
+    request.headers.get("x-skygrid-partner-id") ?? ""
+  ).trim();
+
+  if (!partnerId) {
+    return {
+      ok: false,
+      status: 400,
+      reason: "partner_id_required"
+    };
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    partnerId
+  };
+}
+
+export async function readPilotPayload(
+  request,
+  maximumBytes = MAX_PILOT_PAYLOAD_BYTES
+) {
+  const raw = await request.text();
+  const payloadBytes = encoder.encode(raw).byteLength;
+
+  if (payloadBytes > maximumBytes) {
+    return {
+      ok: false,
+      status: 413,
+      reason: "payload_too_large",
+      payloadBytes
+    };
+  }
+
+  let body;
+
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return {
+      ok: false,
+      status: 400,
+      reason: "invalid_json",
+      payloadBytes
+    };
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      status: 400,
+      reason: "payload_must_be_object",
+      payloadBytes
+    };
+  }
+
+  return {
+    ok: true,
+    body,
+    raw,
+    payloadBytes
+  };
+}
+
+export async function createPilotReceipt({
+  body,
+  rawPayload,
+  payloadBytes,
+  partnerId,
+  correlationId,
+  runtimePayload,
+  httpStatus,
+  processingMs
+}) {
+  const event = runtimePayload?.event ?? {};
+  const decision = event?.decision ?? {};
+
+  const decisionOk =
+    decision.ok === true ||
+    runtimePayload?.accepted === true;
+
+  const auraValidated =
+    decisionOk &&
+    decision.reason === "partition_route_approved" &&
+    decision.mode === "controlled_pilot" &&
+    decision.sentinel === "fail_closed";
+
+  const eventId =
+    event.eventId ??
+    `pilot_${crypto.randomUUID()}`;
+
+  const receivedAt =
+    event.receivedAt ??
+    new Date().toISOString();
+
+  const payloadHash = await sha256Hex(rawPayload);
+
+  const receiptCore = {
+    eventId,
+    partnerId,
+    correlationId,
+    receivedAt,
+    routeType: body.route_type ?? null,
+    requestedRamp: body.requested_ramp ?? null,
+    requestedNode: body.requested_node ?? null,
+    decisionOk,
+    httpStatus,
+    decisionReason:
+      decision.reason ?? "runtime_decision_missing",
+    mode: decision.mode ?? "controlled_pilot",
+    sentinel: decision.sentinel ?? "fail_closed",
+    payloadHash,
+    payloadBytes,
+    processingMs,
+    auraValidated
+  };
+
+  const receiptHash = await sha256Hex(
+    JSON.stringify(receiptCore)
+  );
+
+  return {
+    EventId: eventId,
+    PartnerId: partnerId,
+    CorrelationId: correlationId,
+    ReceivedAt: receivedAt,
+    RouteType: String(body.route_type ?? "unknown"),
+    RequestedRamp: String(
+      body.requested_ramp ?? "unknown"
+    ),
+    RequestedNode: String(
+      body.requested_node ?? "unknown"
+    ),
+    DecisionOk: decisionOk ? 1 : 0,
+    HttpStatus: Number(httpStatus),
+    DecisionReason: String(
+      decision.reason ?? "runtime_decision_missing"
+    ),
+    Mode: String(
+      decision.mode ?? "controlled_pilot"
+    ),
+    Sentinel: String(
+      decision.sentinel ?? "fail_closed"
+    ),
+    OwnerApproval:
+      body.owner_approval === true ? 1 : 0,
+    EmergencyOperatorApproval:
+      body.emergency_operator_approval === true
+        ? 1
+        : 0,
+    PayloadHash: `sha256:${payloadHash}`,
+    PayloadBytes: Number(payloadBytes),
+    ReceiptHash: `sha256:${receiptHash}`,
+    ProcessingMs: Math.max(
+      0,
+      Number(processingMs)
+    ),
+    AuraValidated: auraValidated ? 1 : 0,
+    ReceiptVersion: "1.0"
+  };
+}
+
+export async function persistPilotReceipt(
+  database,
+  receipt
+) {
+  if (!database) {
+    throw new Error("D1 binding MY_DB is unavailable");
+  }
+
+  const statement = database.prepare(`
+    INSERT INTO SkygridPilotEvents (
+      EventId,
+      PartnerId,
+      CorrelationId,
+      ReceivedAt,
+      RouteType,
+      RequestedRamp,
+      RequestedNode,
+      DecisionOk,
+      HttpStatus,
+      DecisionReason,
+      Mode,
+      Sentinel,
+      OwnerApproval,
+      EmergencyOperatorApproval,
+      PayloadHash,
+      PayloadBytes,
+      ReceiptHash,
+      ProcessingMs,
+      AuraValidated,
+      ReceiptVersion
+    ) VALUES (
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    )
+  `);
+
+  return statement.bind(
+    receipt.EventId,
+    receipt.PartnerId,
+    receipt.CorrelationId,
+    receipt.ReceivedAt,
+    receipt.RouteType,
+    receipt.RequestedRamp,
+    receipt.RequestedNode,
+    receipt.DecisionOk,
+    receipt.HttpStatus,
+    receipt.DecisionReason,
+    receipt.Mode,
+    receipt.Sentinel,
+    receipt.OwnerApproval,
+    receipt.EmergencyOperatorApproval,
+    receipt.PayloadHash,
+    receipt.PayloadBytes,
+    receipt.ReceiptHash,
+    receipt.ProcessingMs,
+    receipt.AuraValidated,
+    receipt.ReceiptVersion
+  ).run();
+}

--- a/cloudflare/skygrid-edge-worker/src/pilot-intake.js
+++ b/cloudflare/skygrid-edge-worker/src/pilot-intake.js
@@ -1,0 +1,238 @@
+import {
+  authenticatePilot,
+  createPilotReceipt,
+  persistPilotReceipt,
+  readPilotPayload
+} from "./pilot-evidence.js";
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+      "x-skygrid-edge": "cloudflare-worker"
+    }
+  });
+}
+
+function failureDecision(reason, eventId = null) {
+  return {
+    accepted: false,
+    event: {
+      eventId: eventId ?? `pilot_${crypto.randomUUID()}`,
+      receivedAt: new Date().toISOString(),
+      decision: {
+        ok: false,
+        reason,
+        mode: "controlled_pilot",
+        sentinel: "fail_closed"
+      }
+    }
+  };
+}
+
+function validCorrelationId(value) {
+  return /^[A-Za-z0-9._:-]{8,128}$/.test(value);
+}
+
+function decisionIsStructurallySafe(runtimePayload) {
+  const decision = runtimePayload?.event?.decision;
+
+  if (!decision || typeof decision.ok !== "boolean") {
+    return false;
+  }
+
+  if (decision.ok === false) {
+    return true;
+  }
+
+  return (
+    decision.reason === "partition_route_approved" &&
+    decision.mode === "controlled_pilot" &&
+    decision.sentinel === "fail_closed"
+  );
+}
+
+export async function handlePilotIntake(
+  request,
+  env,
+  {
+    fetchImpl = fetch,
+    origin =
+      env.SKYGRID_ORIGIN ??
+      "https://aurcore.skygrid-protocol.net"
+  } = {}
+) {
+  const authentication = authenticatePilot(request, env);
+
+  if (!authentication.ok) {
+    return json(
+      {
+        ok: false,
+        system: "SKYGRID Emergency Data On-Ramp",
+        reason: authentication.reason
+      },
+      authentication.status
+    );
+  }
+
+  const parsed = await readPilotPayload(request);
+
+  if (!parsed.ok) {
+    return json(
+      {
+        ok: false,
+        system: "SKYGRID Emergency Data On-Ramp",
+        reason: parsed.reason,
+        payloadBytes: parsed.payloadBytes
+      },
+      parsed.status
+    );
+  }
+
+  const correlationId = String(
+    request.headers.get("x-skygrid-correlation-id") ??
+    parsed.body.correlation_id ??
+    ""
+  ).trim();
+
+  if (!validCorrelationId(correlationId)) {
+    return json(
+      {
+        ok: false,
+        system: "SKYGRID Emergency Data On-Ramp",
+        reason: "valid_correlation_id_required"
+      },
+      400
+    );
+  }
+
+  const startedAt = Date.now();
+  let runtimePayload;
+  let runtimeStatus;
+
+  try {
+    const runtimeUrl = new URL(
+      "/api/skygrid/intake",
+      origin
+    );
+
+    const runtimeResponse = await fetchImpl(
+      runtimeUrl.toString(),
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "user-agent":
+            "SKYGRID-Cloudflare-Pilot-Intake/1.0",
+          "x-skygrid-partner-id":
+            authentication.partnerId,
+          "x-skygrid-correlation-id":
+            correlationId
+        },
+        body: JSON.stringify(parsed.body)
+      }
+    );
+
+    runtimeStatus = runtimeResponse.status;
+
+    try {
+      runtimePayload = await runtimeResponse.json();
+    } catch {
+      runtimePayload = failureDecision(
+        "runtime_response_invalid"
+      );
+      runtimeStatus = 502;
+    }
+
+    if (!decisionIsStructurallySafe(runtimePayload)) {
+      runtimePayload = failureDecision(
+        "runtime_policy_mismatch",
+        runtimePayload?.event?.eventId
+      );
+      runtimeStatus = 502;
+    }
+  } catch {
+    runtimePayload = failureDecision(
+      "runtime_unavailable"
+    );
+    runtimeStatus = 502;
+  }
+
+  const processingMs = Date.now() - startedAt;
+
+  const receipt = await createPilotReceipt({
+    body: parsed.body,
+    rawPayload: parsed.raw,
+    payloadBytes: parsed.payloadBytes,
+    partnerId: authentication.partnerId,
+    correlationId,
+    runtimePayload,
+    httpStatus: runtimeStatus,
+    processingMs
+  });
+
+  try {
+    await persistPilotReceipt(env.MY_DB, receipt);
+  } catch (error) {
+    const message = String(error?.message ?? error);
+
+    if (
+      message.includes("UNIQUE constraint failed") ||
+      message.includes("PartnerId") &&
+      message.includes("CorrelationId")
+    ) {
+      return json(
+        {
+          ok: false,
+          system: "SKYGRID Emergency Data On-Ramp",
+          reason: "correlation_already_recorded",
+          correlationId
+        },
+        409
+      );
+    }
+
+    console.error(
+      "Pilot evidence persistence failed",
+      error
+    );
+
+    return json(
+      {
+        ok: false,
+        system: "SKYGRID Emergency Data On-Ramp",
+        reason: "evidence_persistence_failed",
+        sentinel: "fail_closed"
+      },
+      503
+    );
+  }
+
+  return json(
+    {
+      ok: receipt.DecisionOk === 1,
+      accepted: receipt.DecisionOk === 1,
+      system: "SKYGRID Emergency Data On-Ramp",
+      edge: "cloudflare-worker",
+      receipt: {
+        eventId: receipt.EventId,
+        partnerId: receipt.PartnerId,
+        correlationId: receipt.CorrelationId,
+        receivedAt: receipt.ReceivedAt,
+        decisionReason: receipt.DecisionReason,
+        mode: receipt.Mode,
+        sentinel: receipt.Sentinel,
+        payloadHash: receipt.PayloadHash,
+        receiptHash: receipt.ReceiptHash,
+        processingMs: receipt.ProcessingMs,
+        auraValidated:
+          receipt.AuraValidated === 1,
+        receiptVersion: receipt.ReceiptVersion
+      }
+    },
+    runtimeStatus
+  );
+}

--- a/cloudflare/skygrid-edge-worker/test/pilot-evidence.test.mjs
+++ b/cloudflare/skygrid-edge-worker/test/pilot-evidence.test.mjs
@@ -1,0 +1,197 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  authenticatePilot,
+  createPilotReceipt,
+  persistPilotReceipt,
+  readPilotPayload,
+  sha256Hex
+} from "../src/pilot-evidence.js";
+
+test("creates stable SHA-256 hashes", async () => {
+  const first = await sha256Hex("SKYGRID");
+  const second = await sha256Hex("SKYGRID");
+
+  assert.equal(first, second);
+  assert.equal(first.length, 64);
+});
+
+test("requires the pilot API key and partner ID", () => {
+  const missingKeyRequest = new Request("https://example.test");
+
+  assert.deepEqual(
+    authenticatePilot(missingKeyRequest, {
+      SKYGRID_PILOT_API_KEY: "pilot-secret"
+    }),
+    {
+      ok: false,
+      status: 401,
+      reason: "pilot_key_required"
+    }
+  );
+
+  const validRequest = new Request("https://example.test", {
+    headers: {
+      "x-skygrid-pilot-key": "pilot-secret",
+      "x-skygrid-partner-id": "partner-one"
+    }
+  });
+
+  assert.deepEqual(
+    authenticatePilot(validRequest, {
+      SKYGRID_PILOT_API_KEY: "pilot-secret"
+    }),
+    {
+      ok: true,
+      status: 200,
+      partnerId: "partner-one"
+    }
+  );
+});
+
+test("reads a valid pilot payload", async () => {
+  const request = new Request("https://example.test", {
+    method: "POST",
+    body: JSON.stringify({
+      route_type: "diagnostic",
+      requested_ramp: "postman",
+      requested_node: "home"
+    })
+  });
+
+  const result = await readPilotPayload(request);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.body.route_type, "diagnostic");
+  assert.ok(result.payloadBytes > 0);
+});
+
+test("approved route creates one validated Aura unit", async () => {
+  const body = {
+    route_type: "diagnostic",
+    requested_ramp: "postman",
+    requested_node: "home"
+  };
+
+  const rawPayload = JSON.stringify(body);
+
+  const receipt = await createPilotReceipt({
+    body,
+    rawPayload,
+    payloadBytes: new TextEncoder().encode(rawPayload).byteLength,
+    partnerId: "partner-one",
+    correlationId: "correlation-one",
+    runtimePayload: {
+      accepted: true,
+      event: {
+        eventId: "skygrid_test_001",
+        receivedAt: "2026-07-15T04:30:00.000Z",
+        decision: {
+          ok: true,
+          reason: "partition_route_approved",
+          mode: "controlled_pilot",
+          sentinel: "fail_closed"
+        }
+      }
+    },
+    httpStatus: 202,
+    processingMs: 25
+  });
+
+  assert.equal(receipt.EventId, "skygrid_test_001");
+  assert.equal(receipt.DecisionOk, 1);
+  assert.equal(receipt.AuraValidated, 1);
+  assert.match(receipt.PayloadHash, /^sha256:[a-f0-9]{64}$/);
+  assert.match(receipt.ReceiptHash, /^sha256:[a-f0-9]{64}$/);
+});
+
+test("rejected route does not validate Aura", async () => {
+  const body = {
+    route_type: "diagnostic",
+    requested_ramp: "postman",
+    requested_node: "home",
+    wallet_signing_requested: true
+  };
+
+  const rawPayload = JSON.stringify(body);
+
+  const receipt = await createPilotReceipt({
+    body,
+    rawPayload,
+    payloadBytes: new TextEncoder().encode(rawPayload).byteLength,
+    partnerId: "partner-one",
+    correlationId: "correlation-two",
+    runtimePayload: {
+      accepted: false,
+      event: {
+        eventId: "skygrid_test_002",
+        decision: {
+          ok: false,
+          reason: "wallet_signing_prohibited",
+          mode: "controlled_pilot",
+          sentinel: "fail_closed"
+        }
+      }
+    },
+    httpStatus: 403,
+    processingMs: 18
+  });
+
+  assert.equal(receipt.DecisionOk, 0);
+  assert.equal(receipt.AuraValidated, 0);
+});
+
+test("binds and persists the sanitized receipt", async () => {
+  let boundValues;
+  let executed = false;
+
+  const fakeDatabase = {
+    prepare() {
+      return {
+        bind(...values) {
+          boundValues = values;
+
+          return {
+            async run() {
+              executed = true;
+              return {
+                success: true
+              };
+            }
+          };
+        }
+      };
+    }
+  };
+
+  const receipt = {
+    EventId: "skygrid_test_003",
+    PartnerId: "partner-one",
+    CorrelationId: "correlation-three",
+    ReceivedAt: "2026-07-15T04:30:00.000Z",
+    RouteType: "diagnostic",
+    RequestedRamp: "postman",
+    RequestedNode: "home",
+    DecisionOk: 1,
+    HttpStatus: 202,
+    DecisionReason: "partition_route_approved",
+    Mode: "controlled_pilot",
+    Sentinel: "fail_closed",
+    OwnerApproval: 0,
+    EmergencyOperatorApproval: 0,
+    PayloadHash: "sha256:payload",
+    PayloadBytes: 128,
+    ReceiptHash: "sha256:receipt",
+    ProcessingMs: 20,
+    AuraValidated: 1,
+    ReceiptVersion: "1.0"
+  };
+
+  await persistPilotReceipt(fakeDatabase, receipt);
+
+  assert.equal(executed, true);
+  assert.equal(boundValues.length, 20);
+  assert.equal(boundValues[0], "skygrid_test_003");
+  assert.equal(boundValues[18], 1);
+});

--- a/cloudflare/skygrid-edge-worker/test/pilot-intake.test.mjs
+++ b/cloudflare/skygrid-edge-worker/test/pilot-intake.test.mjs
@@ -1,0 +1,415 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import worker from "../src/index.js";
+import { handlePilotIntake } from "../src/pilot-intake.js";
+
+function createFakeDatabase({ runError } = {}) {
+  const state = {
+    sql: null,
+    values: null,
+    runs: 0
+  };
+
+  const database = {
+    prepare(sql) {
+      state.sql = sql;
+
+      return {
+        bind(...values) {
+          state.values = values;
+
+          return {
+            async run() {
+              state.runs += 1;
+
+              if (runError) {
+                throw runError;
+              }
+
+              return {
+                success: true,
+                meta: {
+                  changes: 1
+                }
+              };
+            }
+          };
+        }
+      };
+    }
+  };
+
+  return {
+    database,
+    state
+  };
+}
+
+function createRequest({
+  method = "POST",
+  key = "pilot-secret",
+  partnerId = "partner-one",
+  correlationId = "correlation-001",
+  body = {
+    route_type: "diagnostic",
+    requested_ramp: "postman",
+    requested_node: "home"
+  }
+} = {}) {
+  const headers = {
+    "content-type": "application/json"
+  };
+
+  if (key !== null) {
+    headers["x-skygrid-pilot-key"] = key;
+  }
+
+  if (partnerId !== null) {
+    headers["x-skygrid-partner-id"] = partnerId;
+  }
+
+  if (correlationId !== null) {
+    headers["x-skygrid-correlation-id"] =
+      correlationId;
+  }
+
+  return new Request(
+    "https://edge.test/edge/intake",
+    {
+      method,
+      headers,
+      body:
+        method === "POST"
+          ? JSON.stringify(body)
+          : undefined
+    }
+  );
+}
+
+function approvedRuntimeResponse() {
+  return new Response(
+    JSON.stringify({
+      accepted: true,
+      event: {
+        eventId: "skygrid_pilot_001",
+        receivedAt: "2026-07-15T05:00:00.000Z",
+        decision: {
+          ok: true,
+          reason: "partition_route_approved",
+          mode: "controlled_pilot",
+          sentinel: "fail_closed"
+        }
+      }
+    }),
+    {
+      status: 202,
+      headers: {
+        "content-type": "application/json"
+      }
+    }
+  );
+}
+
+test(
+  "authenticated event receives a PNPK decision and persists sanitized evidence",
+  async () => {
+    const { database, state } =
+      createFakeDatabase();
+
+    const privateMarker =
+      "private-value-must-not-be-persisted";
+
+    const request = createRequest({
+      body: {
+        route_type: "diagnostic",
+        requested_ramp: "postman",
+        requested_node: "home",
+        private_note: privateMarker
+      }
+    });
+
+    let runtimeCalls = 0;
+
+    const response = await handlePilotIntake(
+      request,
+      {
+        SKYGRID_PILOT_API_KEY: "pilot-secret",
+        MY_DB: database
+      },
+      {
+        origin: "https://runtime.test",
+        fetchImpl: async (url, options) => {
+          runtimeCalls += 1;
+
+          assert.equal(
+            url,
+            "https://runtime.test/api/skygrid/intake"
+          );
+
+          assert.equal(options.method, "POST");
+          assert.equal(
+            options.headers["x-skygrid-partner-id"],
+            "partner-one"
+          );
+
+          return approvedRuntimeResponse();
+        }
+      }
+    );
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 202);
+    assert.equal(runtimeCalls, 1);
+    assert.equal(state.runs, 1);
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.accepted, true);
+    assert.equal(
+      payload.receipt.eventId,
+      "skygrid_pilot_001"
+    );
+    assert.equal(
+      payload.receipt.decisionReason,
+      "partition_route_approved"
+    );
+    assert.equal(
+      payload.receipt.mode,
+      "controlled_pilot"
+    );
+    assert.equal(
+      payload.receipt.sentinel,
+      "fail_closed"
+    );
+    assert.equal(
+      payload.receipt.auraValidated,
+      true
+    );
+
+    assert.match(
+      payload.receipt.payloadHash,
+      /^sha256:[a-f0-9]{64}$/
+    );
+
+    assert.match(
+      payload.receipt.receiptHash,
+      /^sha256:[a-f0-9]{64}$/
+    );
+
+    assert.equal(state.values.length, 20);
+    assert.equal(state.values[0], "skygrid_pilot_001");
+    assert.equal(state.values[1], "partner-one");
+    assert.equal(state.values[2], "correlation-001");
+    assert.equal(state.values[7], 1);
+    assert.equal(state.values[8], 202);
+    assert.equal(
+      state.values[9],
+      "partition_route_approved"
+    );
+    assert.equal(state.values[18], 1);
+
+    assert.equal(
+      state.values.some((value) =>
+        String(value).includes(privateMarker)
+      ),
+      false
+    );
+  }
+);
+
+test(
+  "missing pilot key fails before runtime or database access",
+  async () => {
+    let runtimeCalls = 0;
+
+    const response = await handlePilotIntake(
+      createRequest({
+        key: null
+      }),
+      {
+        SKYGRID_PILOT_API_KEY: "pilot-secret",
+        MY_DB: {
+          prepare() {
+            throw new Error(
+              "Database must not be accessed"
+            );
+          }
+        }
+      },
+      {
+        fetchImpl: async () => {
+          runtimeCalls += 1;
+          return approvedRuntimeResponse();
+        }
+      }
+    );
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.reason, "pilot_key_required");
+    assert.equal(runtimeCalls, 0);
+  }
+);
+
+test(
+  "unsafe runtime approval is converted to a fail-closed rejection receipt",
+  async () => {
+    const { database, state } =
+      createFakeDatabase();
+
+    const response = await handlePilotIntake(
+      createRequest({
+        correlationId: "correlation-unsafe"
+      }),
+      {
+        SKYGRID_PILOT_API_KEY: "pilot-secret",
+        MY_DB: database
+      },
+      {
+        origin: "https://runtime.test",
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              accepted: true,
+              event: {
+                eventId: "skygrid_unsafe_001",
+                decision: {
+                  ok: true,
+                  reason:
+                    "partition_route_approved",
+                  mode: "production",
+                  sentinel: "fail_open"
+                }
+              }
+            }),
+            {
+              status: 202,
+              headers: {
+                "content-type":
+                  "application/json"
+              }
+            }
+          )
+      }
+    );
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 502);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.accepted, false);
+
+    assert.equal(
+      payload.receipt.decisionReason,
+      "runtime_policy_mismatch"
+    );
+
+    assert.equal(
+      payload.receipt.auraValidated,
+      false
+    );
+
+    assert.equal(state.runs, 1);
+    assert.equal(state.values[7], 0);
+    assert.equal(state.values[8], 502);
+    assert.equal(
+      state.values[9],
+      "runtime_policy_mismatch"
+    );
+    assert.equal(state.values[18], 0);
+  }
+);
+
+test(
+  "D1 failure prevents an accepted response",
+  async () => {
+    const { database } = createFakeDatabase({
+      runError: new Error("D1 unavailable")
+    });
+
+    const response = await handlePilotIntake(
+      createRequest({
+        correlationId: "correlation-d1-failure"
+      }),
+      {
+        SKYGRID_PILOT_API_KEY: "pilot-secret",
+        MY_DB: database
+      },
+      {
+        fetchImpl: async () =>
+          approvedRuntimeResponse()
+      }
+    );
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 503);
+    assert.equal(
+      payload.reason,
+      "evidence_persistence_failed"
+    );
+    assert.equal(payload.sentinel, "fail_closed");
+  }
+);
+
+test(
+  "duplicate partner correlation returns conflict",
+  async () => {
+    const { database } = createFakeDatabase({
+      runError: new Error(
+        "UNIQUE constraint failed: " +
+        "SkygridPilotEvents.PartnerId, " +
+        "SkygridPilotEvents.CorrelationId"
+      )
+    });
+
+    const response = await handlePilotIntake(
+      createRequest({
+        correlationId: "correlation-duplicate"
+      }),
+      {
+        SKYGRID_PILOT_API_KEY: "pilot-secret",
+        MY_DB: database
+      },
+      {
+        fetchImpl: async () =>
+          approvedRuntimeResponse()
+      }
+    );
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 409);
+    assert.equal(
+      payload.reason,
+      "correlation_already_recorded"
+    );
+    assert.equal(
+      payload.correlationId,
+      "correlation-duplicate"
+    );
+  }
+);
+
+test(
+  "Worker route rejects non-POST intake requests",
+  async () => {
+    const response = await worker.fetch(
+      createRequest({
+        method: "GET"
+      }),
+      {}
+    );
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 405);
+    assert.equal(payload.ok, false);
+    assert.match(
+      payload.message,
+      /POST is required/
+    );
+  }
+);

--- a/cloudflare/skygrid-edge-worker/validate-pilot-constraints.mjs
+++ b/cloudflare/skygrid-edge-worker/validate-pilot-constraints.mjs
@@ -1,0 +1,243 @@
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync
+} from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+
+const temporaryDirectory = fileURLToPath(
+  new URL("./.tmp/", import.meta.url)
+);
+
+const databasePath = fileURLToPath(
+  new URL(
+    "./.tmp/skygrid-pilot-constraints.sqlite",
+    import.meta.url
+  )
+);
+
+const schemaPath = fileURLToPath(
+  new URL(
+    "./schema/skygrid-pilot-events.sql",
+    import.meta.url
+  )
+);
+
+mkdirSync(temporaryDirectory, {
+  recursive: true
+});
+
+rmSync(databasePath, {
+  force: true
+});
+
+const database = new DatabaseSync(databasePath);
+const schema = readFileSync(schemaPath, "utf8");
+
+const insertSql = `
+  INSERT INTO SkygridPilotEvents (
+    EventId,
+    PartnerId,
+    CorrelationId,
+    ReceivedAt,
+    RouteType,
+    RequestedRamp,
+    RequestedNode,
+    DecisionOk,
+    HttpStatus,
+    DecisionReason,
+    Mode,
+    Sentinel,
+    OwnerApproval,
+    EmergencyOperatorApproval,
+    PayloadHash,
+    PayloadBytes,
+    ReceiptHash,
+    ProcessingMs,
+    AuraValidated
+  ) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+  )
+`;
+
+function expectBlocked(name, operation) {
+  try {
+    operation();
+
+    return {
+      name,
+      blocked: false,
+      error:
+        "Constraint unexpectedly permitted the operation"
+    };
+  } catch (error) {
+    return {
+      name,
+      blocked: true,
+      error: String(error.message)
+    };
+  }
+}
+
+try {
+  database.exec(schema);
+
+  const insert = database.prepare(insertSql);
+
+  insert.run(
+    "pilot_local_001",
+    "skygrid_internal",
+    "correlation_local_001",
+    new Date().toISOString(),
+    "diagnostic",
+    "postman",
+    "home",
+    1,
+    202,
+    "partition_route_approved",
+    "controlled_pilot",
+    "fail_closed",
+    0,
+    0,
+    "sha256:test-payload",
+    128,
+    "sha256:test-receipt",
+    25,
+    1
+  );
+
+  const receipt = database.prepare(`
+    SELECT
+      EventId,
+      PartnerId,
+      CorrelationId,
+      DecisionOk,
+      DecisionReason,
+      Mode,
+      Sentinel,
+      AuraValidated,
+      ProcessingMs
+    FROM SkygridPilotEvents
+    WHERE EventId = ?
+  `).get("pilot_local_001");
+
+  const tests = [];
+
+  tests.push(expectBlocked(
+    "duplicate partner correlation",
+    () => insert.run(
+      "pilot_local_002",
+      "skygrid_internal",
+      "correlation_local_001",
+      new Date().toISOString(),
+      "diagnostic",
+      "postman",
+      "home",
+      1,
+      202,
+      "partition_route_approved",
+      "controlled_pilot",
+      "fail_closed",
+      0,
+      0,
+      "sha256:test-payload-2",
+      130,
+      "sha256:test-receipt-2",
+      30,
+      1
+    )
+  ));
+
+  tests.push(expectBlocked(
+    "null event ID",
+    () => insert.run(
+      null,
+      "skygrid_internal",
+      "correlation_null_event",
+      new Date().toISOString(),
+      "diagnostic",
+      "postman",
+      "home",
+      1,
+      202,
+      "partition_route_approved",
+      "controlled_pilot",
+      "fail_closed",
+      0,
+      0,
+      "sha256:null-event",
+      100,
+      "sha256:null-event-receipt",
+      20,
+      1
+    )
+  ));
+
+  tests.push(expectBlocked(
+    "rejected event claiming Aura validation",
+    () => insert.run(
+      "pilot_local_003",
+      "skygrid_internal",
+      "correlation_invalid_aura",
+      new Date().toISOString(),
+      "diagnostic",
+      "postman",
+      "home",
+      0,
+      403,
+      "unsafe_action_requested",
+      "controlled_pilot",
+      "fail_closed",
+      0,
+      0,
+      "sha256:rejected-payload",
+      140,
+      "sha256:rejected-receipt",
+      18,
+      1
+    )
+  ));
+
+  tests.push(expectBlocked(
+    "non-pilot mode",
+    () => insert.run(
+      "pilot_local_004",
+      "skygrid_internal",
+      "correlation_invalid_mode",
+      new Date().toISOString(),
+      "diagnostic",
+      "postman",
+      "home",
+      1,
+      202,
+      "partition_route_approved",
+      "production",
+      "fail_closed",
+      0,
+      0,
+      "sha256:invalid-mode",
+      120,
+      "sha256:invalid-mode-receipt",
+      22,
+      1
+    )
+  ));
+
+  const ok =
+    receipt?.AuraValidated === 1 &&
+    tests.every((test) => test.blocked);
+
+  console.log(JSON.stringify({
+    ok,
+    databasePath,
+    receipt,
+    constraintTests: tests
+  }, null, 2));
+
+  if (!ok) {
+    process.exitCode = 1;
+  }
+} finally {
+  database.close();
+}

--- a/cloudflare/skygrid-edge-worker/validate-pilot-schema.mjs
+++ b/cloudflare/skygrid-edge-worker/validate-pilot-schema.mjs
@@ -1,0 +1,70 @@
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync
+} from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+
+const temporaryDirectory = fileURLToPath(
+  new URL("./.tmp/", import.meta.url)
+);
+
+const databasePath = fileURLToPath(
+  new URL(
+    "./.tmp/skygrid-pilot-schema.sqlite",
+    import.meta.url
+  )
+);
+
+const schemaPath = fileURLToPath(
+  new URL(
+    "./schema/skygrid-pilot-events.sql",
+    import.meta.url
+  )
+);
+
+mkdirSync(temporaryDirectory, {
+  recursive: true
+});
+
+rmSync(databasePath, {
+  force: true
+});
+
+const schema = readFileSync(schemaPath, "utf8");
+const database = new DatabaseSync(databasePath);
+
+try {
+  database.exec(schema);
+
+  const tables = database.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table'
+    ORDER BY name
+  `).all();
+
+  const columns = database
+    .prepare(
+      "PRAGMA table_info('SkygridPilotEvents')"
+    )
+    .all();
+
+  const indexes = database
+    .prepare(
+      "PRAGMA index_list('SkygridPilotEvents')"
+    )
+    .all();
+
+  console.log(JSON.stringify({
+    ok: true,
+    databasePath,
+    tables,
+    columnCount: columns.length,
+    columns,
+    indexes
+  }, null, 2));
+} finally {
+  database.close();
+}

--- a/evidence/node-pilot/node-b0ef83f8ebdac23a26fd0edb78227343e28d0e68b9e0802c4af58064c2328788-control-center-rejection.json
+++ b/evidence/node-pilot/node-b0ef83f8ebdac23a26fd0edb78227343e28d0e68b9e0802c4af58064c2328788-control-center-rejection.json
@@ -1,0 +1,13 @@
+{
+    "schema_version":  "1.0",
+    "service":  "SKYGRID Emergency Data On-Ramp",
+    "mode":  "controlled_pilot",
+    "event_type":  "workload_assignment_rejection",
+    "node_id":  "b0ef83f8ebdac23a26fd0edb78227343e28d0e68b9e0802c4af58064c2328788",
+    "requested_partition":  "diagnostic",
+    "assignment_accepted":  false,
+    "reason":  "node_revoked",
+    "workload_executed":  false,
+    "evaluated_at":  "2026-07-15T10:35:07.7502033-07:00",
+    "ok":  true
+}

--- a/scripts/skygrid-node-control.ps1
+++ b/scripts/skygrid-node-control.ps1
@@ -1,0 +1,105 @@
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet("status", "revoke", "assign")]
+    [string]$Action,
+
+    [Parameter(Mandatory)]
+    [string]$NodeId,
+
+    [string]$Partition = "diagnostic"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$evidenceRoot = Join-Path $repoRoot "evidence\node-pilot"
+
+$enrollmentPath = Join-Path $evidenceRoot "node-$NodeId-enrollment.json"
+$revocationPath = Join-Path $evidenceRoot "node-$NodeId-revocation.json"
+
+if (-not (Test-Path $enrollmentPath)) {
+    throw "Enrollment receipt not found for node $NodeId"
+}
+
+$enrollment = Get-Content $enrollmentPath -Raw | ConvertFrom-Json
+
+switch ($Action) {
+    "status" {
+        $state = if (Test-Path $revocationPath) { "revoked" } else { "active" }
+
+        [ordered]@{
+            node_id = $NodeId
+            lifecycle_state = $state
+            capacity_verified = $enrollment.capacity_verified
+            platform = $enrollment.platform
+            partition = $enrollment.partition
+            centrally_assignable = $state -eq "active"
+            ok = $true
+        } | ConvertTo-Json -Depth 10
+    }
+
+    "revoke" {
+        if (Test-Path $revocationPath) {
+            throw "Node is already revoked."
+        }
+
+        $revocation = [ordered]@{
+            schema_version = "1.0"
+            service = "SKYGRID Emergency Data On-Ramp"
+            mode = "controlled_pilot"
+            event_type = "node_revocation"
+            node_id = $NodeId
+            prior_state = "active"
+            lifecycle_state = "revoked"
+            centrally_assignable = $false
+            heartbeat_status = "disabled"
+            revoked_at = (Get-Date).ToString("o")
+            revocation_reason = "control-center command"
+            enrollment_receipt = Split-Path $enrollmentPath -Leaf
+            enrollment_sha256 = (Get-FileHash $enrollmentPath -Algorithm SHA256).Hash
+            ok = $true
+        }
+
+        [System.IO.File]::WriteAllText(
+            $revocationPath,
+            ($revocation | ConvertTo-Json -Depth 10),
+            [System.Text.UTF8Encoding]::new($false)
+        )
+
+        $revocation | ConvertTo-Json -Depth 10
+    }
+
+    "assign" {
+        if (Test-Path $revocationPath) {
+            [ordered]@{
+                schema_version = "1.0"
+                service = "SKYGRID Emergency Data On-Ramp"
+                mode = "controlled_pilot"
+                event_type = "workload_assignment_rejection"
+                node_id = $NodeId
+                requested_partition = $Partition
+                assignment_accepted = $false
+                reason = "node_revoked"
+                workload_executed = $false
+                evaluated_at = (Get-Date).ToString("o")
+                ok = $true
+            } | ConvertTo-Json -Depth 10
+
+            exit 2
+        }
+
+        [ordered]@{
+            schema_version = "1.0"
+            service = "SKYGRID Emergency Data On-Ramp"
+            mode = "controlled_pilot"
+            event_type = "workload_assignment"
+            node_id = $NodeId
+            requested_partition = $Partition
+            assignment_accepted = $true
+            workload_type = "diagnostic_sha256"
+            production = $false
+            assigned_at = (Get-Date).ToString("o")
+            ok = $true
+        } | ConvertTo-Json -Depth 10
+    }
+}


### PR DESCRIPTION
## Summary

Adds the fail-closed pilot evidence ledger intake for the SKYGRID Emergency Data On-Ramp.

## Changes

- Adds authenticated `POST /edge/intake`
- Forwards synthetic pilot events to the existing PNPK runtime
- Hashes payloads instead of storing raw private data
- Persists sanitized D1 evidence receipts
- Validates one Aura unit only for approved `controlled_pilot` and `fail_closed` decisions
- Rejects duplicate partner correlation IDs
- Fails closed when the runtime response is unsafe or D1 persistence fails
- Adds schema, constraint, module, and mocked integration tests

## Validation

- Schema validation passed
- Database constraint validation passed
- 12 tests passed
- 0 tests failed
- JavaScript syntax checks passed
- `git diff --check` passed

## Deployment status

This PR does not apply the schema remotely or deploy the Worker. Remote D1 migration, Worker secret configuration, and staging deployment remain separate controlled steps.