### PR TITLE
Add SKYGRID milestone funding vault

### DIFF
--- a/.github/workflows/skygrid-contracts.yml
+++ b/.github/workflows/skygrid-contracts.yml
@@ -1,0 +1,53 @@
+name: SKYGRID contract validation
+
+on:
+  pull_request:
+    paths:
+      - "contracts/skygrid-funding/**"
+      - ".github/workflows/skygrid-contracts.yml"
+  push:
+    branches:
+      - MVPuknowme
+    paths:
+      - "contracts/skygrid-funding/**"
+      - ".github/workflows/skygrid-contracts.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  forge-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: contracts/skygrid-funding
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Install pinned Solidity dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p lib
+          git clone --depth 1 --branch v5.4.0 \
+            https://github.com/OpenZeppelin/openzeppelin-contracts.git \
+            lib/openzeppelin-contracts
+          git clone --depth 1 --branch v1.10.0 \
+            https://github.com/foundry-rs/forge-std.git \
+            lib/forge-std
+
+      - name: Check formatting
+        run: forge fmt --check
+
+      - name: Run unit, fuzz, and invariant tests
+        run: forge test -vvv

--- a/.github/workflows/skygrid-contracts.yml
+++ b/.github/workflows/skygrid-contracts.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   forge-test:
@@ -26,10 +26,8 @@ jobs:
         working-directory: contracts/skygrid-funding
 
     steps:
-      - name: Check out pull-request branch
+      - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -48,23 +46,8 @@ jobs:
             https://github.com/foundry-rs/forge-std.git \
             lib/forge-std
 
-      - name: Format Solidity sources
-        run: forge fmt
-
-      - name: Commit Foundry formatting
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet -- src test; then
-            echo "Solidity sources already formatted."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src test
-          git commit -m "Format SKYGRID funding contracts"
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+      - name: Check formatting
+        run: forge fmt --check
 
       - name: Run unit, fuzz, and invariant tests
         run: forge test -vvv

--- a/.github/workflows/skygrid-contracts.yml
+++ b/.github/workflows/skygrid-contracts.yml
@@ -46,8 +46,18 @@ jobs:
             https://github.com/foundry-rs/forge-std.git \
             lib/forge-std
 
-      - name: Check formatting
-        run: forge fmt --check
+      - name: Format Solidity sources
+        run: forge fmt
+
+      - name: Upload formatted Solidity sources
+        uses: actions/upload-artifact@v4
+        with:
+          name: skygrid-formatted-solidity
+          path: |
+            contracts/skygrid-funding/src
+            contracts/skygrid-funding/test
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Run unit, fuzz, and invariant tests
         run: forge test -vvv

--- a/.github/workflows/skygrid-contracts.yml
+++ b/.github/workflows/skygrid-contracts.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   forge-test:
@@ -26,8 +26,10 @@ jobs:
         working-directory: contracts/skygrid-funding
 
     steps:
-      - name: Check out repository
+      - name: Check out pull-request branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -49,15 +51,20 @@ jobs:
       - name: Format Solidity sources
         run: forge fmt
 
-      - name: Upload formatted Solidity sources
-        uses: actions/upload-artifact@v4
-        with:
-          name: skygrid-formatted-solidity
-          path: |
-            contracts/skygrid-funding/src
-            contracts/skygrid-funding/test
-          if-no-files-found: error
-          retention-days: 1
+      - name: Commit Foundry formatting
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- src test; then
+            echo "Solidity sources already formatted."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src test
+          git commit -m "Format SKYGRID funding contracts"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
 
       - name: Run unit, fuzz, and invariant tests
         run: forge test -vvv

--- a/contracts/skygrid-funding/README.md
+++ b/contracts/skygrid-funding/README.md
@@ -1,0 +1,117 @@
+# SKYGRID Milestone Funding Vault
+
+`SkygridMilestoneVault` is the first contract in the SKYGRID funding layer. It accepts one approved ERC-20 payment asset for one defined pilot, holds the complete pilot budget, and resolves each milestone through either:
+
+- release after approval by the configured approval Safe, or
+- refund to the sponsor after the milestone deadline.
+
+It does **not** issue a token, promise returns, price SKYGRID work autonomously, or move emergency data. The SKYGRID Emergency Data On-Ramp remains operationally separate from financial execution.
+
+## Security model
+
+Use contract addresses controlled by multisignature wallets for:
+
+- `governance`: contract administration and emergency pause
+- `approver`: milestone review and release authorization
+- `beneficiaryTreasury`: net pilot proceeds
+- `platformTreasury`: disclosed SKYGRID platform fees
+
+The sponsor is the only account permitted to fund or claim expired milestone refunds.
+
+Important properties:
+
+- full budget must be funded in one transaction
+- fee-on-transfer payment assets are rejected during funding
+- milestone evidence is stored only as a hash
+- sensitive reports remain encrypted and off-chain
+- releases stop after each milestone deadline
+- unresolved milestones become refundable after their deadlines
+- emergency pause blocks funding and release, but never blocks expired refunds
+- payment-token recovery by governance is prohibited
+- native currency deposits are rejected
+- platform fee is disclosed at deployment and capped at 10%
+
+The intended initial SKYGRID fee is `350` basis points, or **3.5%**, paid to the configured platform treasury. Any founder or contractor allocation should be handled under a separately reviewed treasury policy or revenue-router contract rather than a personal withdrawal path in this vault.
+
+## Project structure
+
+```text
+contracts/skygrid-funding/
+├── foundry.toml
+├── remappings.txt
+├── src/
+│   └── SkygridMilestoneVault.sol
+└── test/
+    └── SkygridMilestoneVault.t.sol
+```
+
+## Install and test — PowerShell
+
+Install Foundry first, then run:
+
+```powershell
+cd .\contracts\skygrid-funding
+
+New-Item -ItemType Directory -Force -Path .\lib | Out-Null
+
+git clone --depth 1 --branch v5.4.0 `
+  https://github.com/OpenZeppelin/openzeppelin-contracts.git `
+  .\lib\openzeppelin-contracts
+
+git clone --depth 1 --branch v1.10.0 `
+  https://github.com/foundry-rs/forge-std.git `
+  .\lib\forge-std
+
+forge fmt --check
+forge test -vvv
+```
+
+To rerun without recloning dependencies:
+
+```powershell
+cd .\contracts\skygrid-funding
+forge test -vvv
+```
+
+## Constructor inputs
+
+| Input | Purpose |
+|---|---|
+| `projectId` | Hash identifying the signed pilot agreement |
+| `paymentToken` | Approved standard ERC-20 stablecoin |
+| `sponsor` | Account funding the pilot and receiving eligible refunds |
+| `beneficiaryTreasury` | Safe receiving net milestone proceeds |
+| `platformTreasury` | Safe receiving disclosed platform fees |
+| `governance` | Safe holding admin and pause authority |
+| `approver` | Safe authorized to validate and release milestones |
+| `platformFeeBps` | Fee in basis points; `350` = 3.5% |
+| `fundingDeadline` | Last timestamp at which initial funding is accepted |
+| `milestoneAmounts` | Gross payment assigned to each milestone |
+| `milestoneDeadlines` | Strictly increasing release/refund boundaries |
+
+## Evidence procedure
+
+For every release:
+
+1. Build the PNPK or pilot evidence package off-chain.
+2. Remove or encrypt operationally sensitive information.
+3. Hash the final evidence package.
+4. Record the approval decision through the approval Safe.
+5. Call `releaseMilestone()` with the evidence hash and approval reference.
+
+The contract records integrity proofs, amounts, and resolution status—not emergency payload contents.
+
+## Deployment gate
+
+Do not deploy this vault with real funds until all of the following are recorded:
+
+- signed pilot agreement
+- approved stablecoin and chain
+- sponsor address
+- beneficiary, platform, governance, and approval Safe addresses
+- milestone amounts and deadlines
+- refund language matching the signed agreement
+- independent contract review
+- testnet deployment and end-to-end rehearsal
+
+The contract is EVM-compatible and intentionally chain-neutral. SKYGRID can select Scroll for canonical treasury/ledger use or Base USDC for an approved payment rail without changing the vault logic. No production deployment is included in this change.

--- a/contracts/skygrid-funding/foundry.toml
+++ b/contracts/skygrid-funding/foundry.toml
@@ -1,0 +1,23 @@
+[profile.default]
+src = "src"
+test = "test"
+script = "script"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.24"
+evm_version = "cancun"
+optimizer = true
+optimizer_runs = 200
+
+[fuzz]
+runs = 512
+
+[invariant]
+runs = 128
+depth = 64
+fail_on_revert = false
+
+[fmt]
+line_length = 100
+tab_width = 4
+bracket_spacing = true

--- a/contracts/skygrid-funding/remappings.txt
+++ b/contracts/skygrid-funding/remappings.txt
@@ -1,0 +1,2 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+forge-std/=lib/forge-std/src/

--- a/contracts/skygrid-funding/src/SkygridMilestoneVault.sol
+++ b/contracts/skygrid-funding/src/SkygridMilestoneVault.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
-import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @title SKYGRID Milestone Vault
 /// @notice Holds one approved ERC-20 payment asset for a defined SKYGRID pilot and
@@ -64,7 +64,9 @@ contract SkygridMilestoneVault is AccessControl, Pausable, ReentrancyGuard {
         uint256 beneficiaryAmount
     );
     event MilestoneRefunded(uint256 indexed milestoneId, address indexed sponsor, uint256 amount);
-    event UnsupportedTokenRecovered(address indexed token, address indexed recipient, uint256 amount);
+    event UnsupportedTokenRecovered(
+        address indexed token, address indexed recipient, uint256 amount
+    );
 
     bytes32 public immutable projectId;
     IERC20 public immutable paymentToken;
@@ -123,7 +125,10 @@ contract SkygridMilestoneVault is AccessControl, Pausable, ReentrancyGuard {
         for (uint256 i; i < milestoneCount_; ++i) {
             uint128 amount = milestoneAmounts_[i];
             uint64 deadline = milestoneDeadlines_[i];
-            if (amount == 0 || deadline <= block.timestamp || (i > 0 && deadline <= previousDeadline)) {
+            if (
+                amount == 0 || deadline <= block.timestamp
+                    || (i > 0 && deadline <= previousDeadline)
+            ) {
                 revert InvalidMilestoneConfiguration();
             }
 
@@ -207,12 +212,7 @@ contract SkygridMilestoneVault is AccessControl, Pausable, ReentrancyGuard {
         if (fee != 0) paymentToken.safeTransfer(platformTreasury, fee);
 
         emit MilestoneReleased(
-            milestoneId,
-            evidenceHash,
-            approvalRef,
-            grossAmount,
-            fee,
-            beneficiaryAmount
+            milestoneId, evidenceHash, approvalRef, grossAmount, fee, beneficiaryAmount
         );
     }
 
@@ -252,7 +252,9 @@ contract SkygridMilestoneVault is AccessControl, Pausable, ReentrancyGuard {
         onlyRole(DEFAULT_ADMIN_ROLE)
         nonReentrant
     {
-        if (address(token) == address(paymentToken)) revert PaymentTokenRecoveryForbidden();
+        if (address(token) == address(paymentToken)) {
+            revert PaymentTokenRecoveryForbidden();
+        }
         if (recipient == address(0)) revert ZeroAddress();
 
         uint256 amount = token.balanceOf(address(this));

--- a/contracts/skygrid-funding/src/SkygridMilestoneVault.sol
+++ b/contracts/skygrid-funding/src/SkygridMilestoneVault.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title SKYGRID Milestone Vault
+/// @notice Holds one approved ERC-20 payment asset for a defined SKYGRID pilot and
+///         releases each milestone only after approval by the configured approver.
+/// @dev The approver and governance addresses should be multisignature wallets.
+///      This contract does not issue a token, promise yield, or autonomously price work.
+contract SkygridMilestoneVault is AccessControl, Pausable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    bytes32 public constant APPROVER_ROLE = keccak256("APPROVER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    uint16 public constant MAX_PLATFORM_FEE_BPS = 1_000; // 10% hard ceiling
+
+    enum MilestoneStatus {
+        Pending,
+        Released,
+        Refunded
+    }
+
+    struct Milestone {
+        uint128 grossAmount;
+        uint64 deadline;
+        MilestoneStatus status;
+        bytes32 evidenceHash;
+        bytes32 approvalRef;
+    }
+
+    error ZeroAddress();
+    error InvalidProjectId();
+    error InvalidMilestoneConfiguration();
+    error InvalidFundingDeadline();
+    error InvalidPlatformFee(uint256 feeBps);
+    error OnlySponsor(address caller);
+    error FundingClosed(uint256 currentTime, uint256 deadline);
+    error AlreadyFunded();
+    error VaultNotFunded();
+    error UnsupportedPaymentTokenBehavior(uint256 expected, uint256 received);
+    error InvalidMilestone(uint256 milestoneId);
+    error MilestoneAlreadyResolved(uint256 milestoneId);
+    error MilestoneReleaseExpired(uint256 milestoneId, uint256 deadline);
+    error RefundNotAvailable(uint256 milestoneId, uint256 deadline);
+    error MissingEvidence();
+    error MissingApprovalReference();
+    error PaymentTokenRecoveryForbidden();
+    error NativeCurrencyNotAccepted();
+
+    event VaultFunded(address indexed sponsor, uint256 amount);
+    event MilestoneReleased(
+        uint256 indexed milestoneId,
+        bytes32 indexed evidenceHash,
+        bytes32 indexed approvalRef,
+        uint256 grossAmount,
+        uint256 platformFee,
+        uint256 beneficiaryAmount
+    );
+    event MilestoneRefunded(uint256 indexed milestoneId, address indexed sponsor, uint256 amount);
+    event UnsupportedTokenRecovered(address indexed token, address indexed recipient, uint256 amount);
+
+    bytes32 public immutable projectId;
+    IERC20 public immutable paymentToken;
+    address public immutable sponsor;
+    address public immutable beneficiaryTreasury;
+    address public immutable platformTreasury;
+    uint16 public immutable platformFeeBps;
+    uint64 public immutable fundingDeadline;
+    uint256 public immutable totalBudget;
+
+    bool public funded;
+    uint256 public totalReleased;
+    uint256 public totalRefunded;
+
+    Milestone[] private _milestones;
+
+    modifier onlySponsor() {
+        if (msg.sender != sponsor) revert OnlySponsor(msg.sender);
+        _;
+    }
+
+    constructor(
+        bytes32 projectId_,
+        IERC20 paymentToken_,
+        address sponsor_,
+        address beneficiaryTreasury_,
+        address platformTreasury_,
+        address governance_,
+        address approver_,
+        uint16 platformFeeBps_,
+        uint64 fundingDeadline_,
+        uint128[] memory milestoneAmounts_,
+        uint64[] memory milestoneDeadlines_
+    ) {
+        if (projectId_ == bytes32(0)) revert InvalidProjectId();
+        if (
+            address(paymentToken_) == address(0) || sponsor_ == address(0)
+                || beneficiaryTreasury_ == address(0) || platformTreasury_ == address(0)
+                || governance_ == address(0) || approver_ == address(0)
+        ) revert ZeroAddress();
+        if (address(paymentToken_).code.length == 0) revert ZeroAddress();
+        if (platformFeeBps_ > MAX_PLATFORM_FEE_BPS) {
+            revert InvalidPlatformFee(platformFeeBps_);
+        }
+
+        uint256 milestoneCount_ = milestoneAmounts_.length;
+        if (milestoneCount_ == 0 || milestoneCount_ != milestoneDeadlines_.length) {
+            revert InvalidMilestoneConfiguration();
+        }
+        if (fundingDeadline_ <= block.timestamp || fundingDeadline_ >= milestoneDeadlines_[0]) {
+            revert InvalidFundingDeadline();
+        }
+
+        uint256 budget;
+        uint64 previousDeadline;
+        for (uint256 i; i < milestoneCount_; ++i) {
+            uint128 amount = milestoneAmounts_[i];
+            uint64 deadline = milestoneDeadlines_[i];
+            if (amount == 0 || deadline <= block.timestamp || (i > 0 && deadline <= previousDeadline)) {
+                revert InvalidMilestoneConfiguration();
+            }
+
+            budget += amount;
+            previousDeadline = deadline;
+            _milestones.push(
+                Milestone({
+                    grossAmount: amount,
+                    deadline: deadline,
+                    status: MilestoneStatus.Pending,
+                    evidenceHash: bytes32(0),
+                    approvalRef: bytes32(0)
+                })
+            );
+        }
+
+        projectId = projectId_;
+        paymentToken = paymentToken_;
+        sponsor = sponsor_;
+        beneficiaryTreasury = beneficiaryTreasury_;
+        platformTreasury = platformTreasury_;
+        platformFeeBps = platformFeeBps_;
+        fundingDeadline = fundingDeadline_;
+        totalBudget = budget;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, governance_);
+        _grantRole(PAUSER_ROLE, governance_);
+        _grantRole(APPROVER_ROLE, approver_);
+    }
+
+    /// @notice Funds the complete pilot budget in a single transaction.
+    /// @dev The sponsor must approve exactly `totalBudget` before calling.
+    function fund() external onlySponsor whenNotPaused nonReentrant {
+        if (funded) revert AlreadyFunded();
+        if (block.timestamp > fundingDeadline) {
+            revert FundingClosed(block.timestamp, fundingDeadline);
+        }
+
+        uint256 balanceBefore = paymentToken.balanceOf(address(this));
+        paymentToken.safeTransferFrom(sponsor, address(this), totalBudget);
+        uint256 received = paymentToken.balanceOf(address(this)) - balanceBefore;
+        if (received != totalBudget) {
+            revert UnsupportedPaymentTokenBehavior(totalBudget, received);
+        }
+
+        funded = true;
+        emit VaultFunded(sponsor, received);
+    }
+
+    /// @notice Releases one milestone after the approver validates its evidence.
+    /// @param milestoneId Index of the milestone.
+    /// @param evidenceHash Hash of the off-chain evidence package; never store sensitive data directly.
+    /// @param approvalRef Hash/reference for the signed approval record or governance decision.
+    function releaseMilestone(uint256 milestoneId, bytes32 evidenceHash, bytes32 approvalRef)
+        external
+        onlyRole(APPROVER_ROLE)
+        whenNotPaused
+        nonReentrant
+    {
+        if (!funded) revert VaultNotFunded();
+        Milestone storage milestone = _milestoneAt(milestoneId);
+        if (milestone.status != MilestoneStatus.Pending) {
+            revert MilestoneAlreadyResolved(milestoneId);
+        }
+        if (block.timestamp > milestone.deadline) {
+            revert MilestoneReleaseExpired(milestoneId, milestone.deadline);
+        }
+        if (evidenceHash == bytes32(0)) revert MissingEvidence();
+        if (approvalRef == bytes32(0)) revert MissingApprovalReference();
+
+        uint256 grossAmount = milestone.grossAmount;
+        uint256 fee = (grossAmount * platformFeeBps) / BPS_DENOMINATOR;
+        uint256 beneficiaryAmount = grossAmount - fee;
+
+        milestone.status = MilestoneStatus.Released;
+        milestone.evidenceHash = evidenceHash;
+        milestone.approvalRef = approvalRef;
+        totalReleased += grossAmount;
+
+        paymentToken.safeTransfer(beneficiaryTreasury, beneficiaryAmount);
+        if (fee != 0) paymentToken.safeTransfer(platformTreasury, fee);
+
+        emit MilestoneReleased(
+            milestoneId,
+            evidenceHash,
+            approvalRef,
+            grossAmount,
+            fee,
+            beneficiaryAmount
+        );
+    }
+
+    /// @notice Refunds an unresolved milestone after its deadline.
+    /// @dev Refunds deliberately remain available while the vault is paused so governance
+    ///      cannot use the emergency stop to trap sponsor funds.
+    function refundMilestone(uint256 milestoneId) external onlySponsor nonReentrant {
+        if (!funded) revert VaultNotFunded();
+        Milestone storage milestone = _milestoneAt(milestoneId);
+        if (milestone.status != MilestoneStatus.Pending) {
+            revert MilestoneAlreadyResolved(milestoneId);
+        }
+        if (block.timestamp <= milestone.deadline) {
+            revert RefundNotAvailable(milestoneId, milestone.deadline);
+        }
+
+        uint256 amount = milestone.grossAmount;
+        milestone.status = MilestoneStatus.Refunded;
+        totalRefunded += amount;
+
+        paymentToken.safeTransfer(sponsor, amount);
+        emit MilestoneRefunded(milestoneId, sponsor, amount);
+    }
+
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    /// @notice Recovers unrelated tokens accidentally sent to the vault.
+    /// @dev The configured payment token cannot be recovered through this function.
+    function recoverUnsupportedToken(IERC20 token, address recipient)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        nonReentrant
+    {
+        if (address(token) == address(paymentToken)) revert PaymentTokenRecoveryForbidden();
+        if (recipient == address(0)) revert ZeroAddress();
+
+        uint256 amount = token.balanceOf(address(this));
+        token.safeTransfer(recipient, amount);
+        emit UnsupportedTokenRecovered(address(token), recipient, amount);
+    }
+
+    function milestoneCount() external view returns (uint256) {
+        return _milestones.length;
+    }
+
+    function milestone(uint256 milestoneId) external view returns (Milestone memory) {
+        if (milestoneId >= _milestones.length) revert InvalidMilestone(milestoneId);
+        return _milestones[milestoneId];
+    }
+
+    function unresolvedAmount() external view returns (uint256) {
+        return totalBudget - totalReleased - totalRefunded;
+    }
+
+    function expectedPlatformFee(uint256 milestoneId) external view returns (uint256) {
+        Milestone storage item = _milestoneAt(milestoneId);
+        return (uint256(item.grossAmount) * platformFeeBps) / BPS_DENOMINATOR;
+    }
+
+    receive() external payable {
+        revert NativeCurrencyNotAccepted();
+    }
+
+    function _milestoneAt(uint256 milestoneId) internal view returns (Milestone storage item) {
+        if (milestoneId >= _milestones.length) revert InvalidMilestone(milestoneId);
+        item = _milestones[milestoneId];
+    }
+}

--- a/contracts/skygrid-funding/test/SkygridMilestoneVault.t.sol
+++ b/contracts/skygrid-funding/test/SkygridMilestoneVault.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {StdInvariant} from "forge-std/StdInvariant.sol";
-import {Test} from "forge-std/Test.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { Test } from "forge-std/Test.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import {SkygridMilestoneVault} from "../src/SkygridMilestoneVault.sol";
+import { SkygridMilestoneVault } from "../src/SkygridMilestoneVault.sol";
 
 contract MockUSDC is ERC20 {
-    constructor() ERC20("Mock USD Coin", "mUSDC") {}
+    constructor() ERC20("Mock USD Coin", "mUSDC") { }
 
     function decimals() public pure override returns (uint8) {
         return 6;
@@ -194,10 +194,7 @@ contract SkygridMilestoneVaultTest is Test {
         vm.warp(uint256(firstDeadline) + 1);
         vm.prank(sponsor);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                SkygridMilestoneVault.MilestoneAlreadyResolved.selector,
-                0
-            )
+            abi.encodeWithSelector(SkygridMilestoneVault.MilestoneAlreadyResolved.selector, 0)
         );
         vault.refundMilestone(0);
     }
@@ -241,7 +238,7 @@ contract SkygridMilestoneVaultTest is Test {
     function testRejectsNativeCurrency() public {
         vm.deal(address(this), 1 ether);
 
-        (bool success, bytes memory revertData) = address(vault).call{value: 1 ether}("");
+        (bool success, bytes memory revertData) = address(vault).call{ value: 1 ether }("");
 
         assertFalse(success);
         assertEq(bytes4(revertData), SkygridMilestoneVault.NativeCurrencyNotAccepted.selector);
@@ -308,7 +305,7 @@ contract SkygridVaultHandler is Test {
         if (approvalRef == bytes32(0)) approvalRef = bytes32(uint256(2));
 
         vm.prank(approver);
-        try vault.releaseMilestone(milestoneId, evidenceHash, approvalRef) {} catch {}
+        try vault.releaseMilestone(milestoneId, evidenceHash, approvalRef) { } catch { }
     }
 
     function refund(uint256 rawId) external {
@@ -322,7 +319,7 @@ contract SkygridVaultHandler is Test {
         ) return;
 
         vm.prank(sponsor);
-        try vault.refundMilestone(milestoneId) {} catch {}
+        try vault.refundMilestone(milestoneId) { } catch { }
     }
 }
 
@@ -380,8 +377,8 @@ contract SkygridMilestoneVaultInvariantTest is StdInvariant, Test {
     }
 
     function invariantBudgetIsAlwaysConserved() public {
-        uint256 accounted = token.balanceOf(address(vault)) + vault.totalReleased()
-            + vault.totalRefunded();
+        uint256 accounted =
+            token.balanceOf(address(vault)) + vault.totalReleased() + vault.totalRefunded();
         assertEq(accounted, vault.totalBudget());
     }
 

--- a/contracts/skygrid-funding/test/SkygridMilestoneVault.t.sol
+++ b/contracts/skygrid-funding/test/SkygridMilestoneVault.t.sol
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {SkygridMilestoneVault} from "../src/SkygridMilestoneVault.sol";
+
+contract MockUSDC is ERC20 {
+    constructor() ERC20("Mock USD Coin", "mUSDC") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address recipient, uint256 amount) external {
+        _mint(recipient, amount);
+    }
+}
+
+contract SkygridMilestoneVaultTest is Test {
+    uint256 internal constant TOTAL_BUDGET = 1_000_000e6;
+    uint16 internal constant PLATFORM_FEE_BPS = 350;
+
+    MockUSDC internal token;
+    SkygridMilestoneVault internal vault;
+
+    address internal sponsor = makeAddr("sponsor");
+    address internal beneficiaryTreasury = makeAddr("beneficiary-safe");
+    address internal platformTreasury = makeAddr("skygrid-safe");
+    address internal governance = makeAddr("governance-safe");
+    address internal approver = makeAddr("approval-safe");
+    address internal outsider = makeAddr("outsider");
+
+    uint64 internal fundingDeadline;
+    uint64 internal firstDeadline;
+
+    function setUp() public {
+        vm.warp(1_800_000_000);
+        token = new MockUSDC();
+
+        uint128[] memory amounts = new uint128[](4);
+        amounts[0] = 200_000e6;
+        amounts[1] = 300_000e6;
+        amounts[2] = 300_000e6;
+        amounts[3] = 200_000e6;
+
+        uint64[] memory deadlines = new uint64[](4);
+        deadlines[0] = uint64(block.timestamp + 30 days);
+        deadlines[1] = uint64(block.timestamp + 60 days);
+        deadlines[2] = uint64(block.timestamp + 90 days);
+        deadlines[3] = uint64(block.timestamp + 120 days);
+
+        fundingDeadline = uint64(block.timestamp + 7 days);
+        firstDeadline = deadlines[0];
+
+        vault = new SkygridMilestoneVault(
+            keccak256("SKYGRID-PILOT-001"),
+            IERC20(address(token)),
+            sponsor,
+            beneficiaryTreasury,
+            platformTreasury,
+            governance,
+            approver,
+            PLATFORM_FEE_BPS,
+            fundingDeadline,
+            amounts,
+            deadlines
+        );
+
+        token.mint(sponsor, TOTAL_BUDGET);
+        vm.prank(sponsor);
+        token.approve(address(vault), TOTAL_BUDGET);
+    }
+
+    function testSponsorFundsCompleteBudget() public {
+        _fund();
+
+        assertTrue(vault.funded());
+        assertEq(token.balanceOf(address(vault)), TOTAL_BUDGET);
+        assertEq(vault.totalBudget(), TOTAL_BUDGET);
+        assertEq(vault.unresolvedAmount(), TOTAL_BUDGET);
+        assertEq(vault.milestoneCount(), 4);
+    }
+
+    function testOnlySponsorCanFund() public {
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(SkygridMilestoneVault.OnlySponsor.selector, outsider)
+        );
+        vault.fund();
+    }
+
+    function testCannotFundTwice() public {
+        _fund();
+
+        vm.prank(sponsor);
+        vm.expectRevert(SkygridMilestoneVault.AlreadyFunded.selector);
+        vault.fund();
+    }
+
+    function testCannotFundAfterFundingDeadline() public {
+        vm.warp(uint256(fundingDeadline) + 1);
+
+        vm.prank(sponsor);
+        vm.expectRevert();
+        vault.fund();
+    }
+
+    function testApproverReleasesMilestoneAndSplitsFee() public {
+        _fund();
+
+        bytes32 evidenceHash = keccak256("encrypted-evidence-package");
+        bytes32 approvalRef = keccak256("safe-transaction-reference");
+        uint256 gross = 200_000e6;
+        uint256 fee = (gross * PLATFORM_FEE_BPS) / 10_000;
+
+        vm.prank(approver);
+        vault.releaseMilestone(0, evidenceHash, approvalRef);
+
+        assertEq(token.balanceOf(beneficiaryTreasury), gross - fee);
+        assertEq(token.balanceOf(platformTreasury), fee);
+        assertEq(vault.totalReleased(), gross);
+        assertEq(vault.totalRefunded(), 0);
+        assertEq(vault.unresolvedAmount(), TOTAL_BUDGET - gross);
+
+        SkygridMilestoneVault.Milestone memory item = vault.milestone(0);
+        assertEq(uint8(item.status), uint8(SkygridMilestoneVault.MilestoneStatus.Released));
+        assertEq(item.evidenceHash, evidenceHash);
+        assertEq(item.approvalRef, approvalRef);
+    }
+
+    function testNonApproverCannotRelease() public {
+        _fund();
+
+        vm.prank(outsider);
+        vm.expectRevert();
+        vault.releaseMilestone(0, keccak256("evidence"), keccak256("approval"));
+    }
+
+    function testReleaseRequiresEvidenceAndApprovalReference() public {
+        _fund();
+
+        vm.startPrank(approver);
+        vm.expectRevert(SkygridMilestoneVault.MissingEvidence.selector);
+        vault.releaseMilestone(0, bytes32(0), keccak256("approval"));
+
+        vm.expectRevert(SkygridMilestoneVault.MissingApprovalReference.selector);
+        vault.releaseMilestone(0, keccak256("evidence"), bytes32(0));
+        vm.stopPrank();
+    }
+
+    function testCannotReleaseAfterMilestoneDeadline() public {
+        _fund();
+        vm.warp(uint256(firstDeadline) + 1);
+
+        vm.prank(approver);
+        vm.expectRevert();
+        vault.releaseMilestone(0, keccak256("evidence"), keccak256("approval"));
+    }
+
+    function testSponsorRefundsExpiredUnresolvedMilestone() public {
+        _fund();
+        uint256 sponsorBalanceBefore = token.balanceOf(sponsor);
+        vm.warp(uint256(firstDeadline) + 1);
+
+        vm.prank(sponsor);
+        vault.refundMilestone(0);
+
+        assertEq(token.balanceOf(sponsor), sponsorBalanceBefore + 200_000e6);
+        assertEq(vault.totalRefunded(), 200_000e6);
+        assertEq(vault.unresolvedAmount(), TOTAL_BUDGET - 200_000e6);
+
+        SkygridMilestoneVault.Milestone memory item = vault.milestone(0);
+        assertEq(uint8(item.status), uint8(SkygridMilestoneVault.MilestoneStatus.Refunded));
+    }
+
+    function testCannotRefundBeforeDeadline() public {
+        _fund();
+
+        vm.prank(sponsor);
+        vm.expectRevert();
+        vault.refundMilestone(0);
+    }
+
+    function testMilestoneCannotBeResolvedTwice() public {
+        _fund();
+
+        vm.prank(approver);
+        vault.releaseMilestone(0, keccak256("evidence"), keccak256("approval"));
+
+        vm.warp(uint256(firstDeadline) + 1);
+        vm.prank(sponsor);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SkygridMilestoneVault.MilestoneAlreadyResolved.selector,
+                0
+            )
+        );
+        vault.refundMilestone(0);
+    }
+
+    function testPauseBlocksReleaseButDoesNotTrapExpiredRefund() public {
+        _fund();
+
+        vm.prank(governance);
+        vault.pause();
+
+        vm.prank(approver);
+        vm.expectRevert();
+        vault.releaseMilestone(0, keccak256("evidence"), keccak256("approval"));
+
+        vm.warp(uint256(firstDeadline) + 1);
+        vm.prank(sponsor);
+        vault.refundMilestone(0);
+
+        assertEq(vault.totalRefunded(), 200_000e6);
+    }
+
+    function testPaymentTokenCannotBeRecoveredByGovernance() public {
+        _fund();
+
+        vm.prank(governance);
+        vm.expectRevert(SkygridMilestoneVault.PaymentTokenRecoveryForbidden.selector);
+        vault.recoverUnsupportedToken(IERC20(address(token)), governance);
+    }
+
+    function testGovernanceCanRecoverUnrelatedToken() public {
+        MockUSDC unrelated = new MockUSDC();
+        unrelated.mint(address(vault), 10e6);
+
+        vm.prank(governance);
+        vault.recoverUnsupportedToken(IERC20(address(unrelated)), governance);
+
+        assertEq(unrelated.balanceOf(governance), 10e6);
+        assertEq(unrelated.balanceOf(address(vault)), 0);
+    }
+
+    function testRejectsNativeCurrency() public {
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(SkygridMilestoneVault.NativeCurrencyNotAccepted.selector);
+        (bool success,) = address(vault).call{value: 1 ether}("");
+        success;
+    }
+
+    function testConstructorRejectsFeeAboveHardCeiling() public {
+        uint128[] memory amounts = new uint128[](1);
+        amounts[0] = 1e6;
+        uint64[] memory deadlines = new uint64[](1);
+        deadlines[0] = uint64(block.timestamp + 30 days);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(SkygridMilestoneVault.InvalidPlatformFee.selector, 1_001)
+        );
+        new SkygridMilestoneVault(
+            keccak256("SKYGRID-PILOT-INVALID-FEE"),
+            IERC20(address(token)),
+            sponsor,
+            beneficiaryTreasury,
+            platformTreasury,
+            governance,
+            approver,
+            1_001,
+            uint64(block.timestamp + 7 days),
+            amounts,
+            deadlines
+        );
+    }
+
+    function _fund() internal {
+        vm.prank(sponsor);
+        vault.fund();
+    }
+}
+
+contract SkygridVaultHandler is Test {
+    SkygridMilestoneVault internal immutable vault;
+    address internal immutable sponsor;
+    address internal immutable approver;
+
+    constructor(SkygridMilestoneVault vault_, address sponsor_, address approver_) {
+        vault = vault_;
+        sponsor = sponsor_;
+        approver = approver_;
+    }
+
+    function advanceTime(uint256 secondsForward) external {
+        secondsForward = bound(secondsForward, 0, 180 days);
+        vm.warp(block.timestamp + secondsForward);
+    }
+
+    function release(uint256 rawId, bytes32 evidenceHash, bytes32 approvalRef) external {
+        uint256 count = vault.milestoneCount();
+        uint256 milestoneId = rawId % count;
+        SkygridMilestoneVault.Milestone memory item = vault.milestone(milestoneId);
+
+        if (
+            item.status != SkygridMilestoneVault.MilestoneStatus.Pending
+                || block.timestamp > item.deadline
+        ) return;
+
+        if (evidenceHash == bytes32(0)) evidenceHash = bytes32(uint256(1));
+        if (approvalRef == bytes32(0)) approvalRef = bytes32(uint256(2));
+
+        vm.prank(approver);
+        try vault.releaseMilestone(milestoneId, evidenceHash, approvalRef) {} catch {}
+    }
+
+    function refund(uint256 rawId) external {
+        uint256 count = vault.milestoneCount();
+        uint256 milestoneId = rawId % count;
+        SkygridMilestoneVault.Milestone memory item = vault.milestone(milestoneId);
+
+        if (
+            item.status != SkygridMilestoneVault.MilestoneStatus.Pending
+                || block.timestamp <= item.deadline
+        ) return;
+
+        vm.prank(sponsor);
+        try vault.refundMilestone(milestoneId) {} catch {}
+    }
+}
+
+contract SkygridMilestoneVaultInvariantTest is StdInvariant, Test {
+    uint256 internal constant TOTAL_BUDGET = 1_000_000e6;
+
+    MockUSDC internal token;
+    SkygridMilestoneVault internal vault;
+    SkygridVaultHandler internal handler;
+
+    address internal sponsor = makeAddr("invariant-sponsor");
+    address internal beneficiaryTreasury = makeAddr("invariant-beneficiary-safe");
+    address internal platformTreasury = makeAddr("invariant-platform-safe");
+    address internal governance = makeAddr("invariant-governance-safe");
+    address internal approver = makeAddr("invariant-approver-safe");
+
+    function setUp() public {
+        vm.warp(1_800_000_000);
+        token = new MockUSDC();
+
+        uint128[] memory amounts = new uint128[](4);
+        amounts[0] = 200_000e6;
+        amounts[1] = 300_000e6;
+        amounts[2] = 300_000e6;
+        amounts[3] = 200_000e6;
+
+        uint64[] memory deadlines = new uint64[](4);
+        deadlines[0] = uint64(block.timestamp + 30 days);
+        deadlines[1] = uint64(block.timestamp + 60 days);
+        deadlines[2] = uint64(block.timestamp + 90 days);
+        deadlines[3] = uint64(block.timestamp + 120 days);
+
+        vault = new SkygridMilestoneVault(
+            keccak256("SKYGRID-INVARIANT-PILOT"),
+            IERC20(address(token)),
+            sponsor,
+            beneficiaryTreasury,
+            platformTreasury,
+            governance,
+            approver,
+            350,
+            uint64(block.timestamp + 7 days),
+            amounts,
+            deadlines
+        );
+
+        token.mint(sponsor, TOTAL_BUDGET);
+        vm.startPrank(sponsor);
+        token.approve(address(vault), TOTAL_BUDGET);
+        vault.fund();
+        vm.stopPrank();
+
+        handler = new SkygridVaultHandler(vault, sponsor, approver);
+        targetContract(address(handler));
+    }
+
+    function invariantBudgetIsAlwaysConserved() public view {
+        uint256 accounted = token.balanceOf(address(vault)) + vault.totalReleased()
+            + vault.totalRefunded();
+        assertEq(accounted, vault.totalBudget());
+    }
+
+    function invariantResolvedAmountsNeverExceedBudget() public view {
+        assertLe(vault.totalReleased() + vault.totalRefunded(), vault.totalBudget());
+    }
+}

--- a/contracts/skygrid-funding/test/SkygridMilestoneVault.t.sol
+++ b/contracts/skygrid-funding/test/SkygridMilestoneVault.t.sol
@@ -240,9 +240,12 @@ contract SkygridMilestoneVaultTest is Test {
 
     function testRejectsNativeCurrency() public {
         vm.deal(address(this), 1 ether);
-        vm.expectRevert(SkygridMilestoneVault.NativeCurrencyNotAccepted.selector);
-        (bool success,) = address(vault).call{value: 1 ether}("");
-        success;
+
+        (bool success, bytes memory revertData) = address(vault).call{value: 1 ether}("");
+
+        assertFalse(success);
+        assertEq(bytes4(revertData), SkygridMilestoneVault.NativeCurrencyNotAccepted.selector);
+        assertEq(address(vault).balance, 0);
     }
 
     function testConstructorRejectsFeeAboveHardCeiling() public {
@@ -376,13 +379,13 @@ contract SkygridMilestoneVaultInvariantTest is StdInvariant, Test {
         targetContract(address(handler));
     }
 
-    function invariantBudgetIsAlwaysConserved() public view {
+    function invariantBudgetIsAlwaysConserved() public {
         uint256 accounted = token.balanceOf(address(vault)) + vault.totalReleased()
             + vault.totalRefunded();
         assertEq(accounted, vault.totalBudget());
     }
 
-    function invariantResolvedAmountsNeverExceedBudget() public view {
+    function invariantResolvedAmountsNeverExceedBudget() public {
         assertLe(vault.totalReleased() + vault.totalRefunded(), vault.totalBudget());
     }
 }


### PR DESCRIPTION
## What changed

- adds `SkygridMilestoneVault.sol` as a chain-neutral, stablecoin-funded pilot escrow
- requires complete budget funding by the named sponsor
- releases milestones only through the configured approval Safe
- splits each release between the beneficiary treasury and disclosed platform treasury fee
- allows sponsor refunds after unresolved milestone deadlines
- keeps expired refunds available during an emergency pause
- prohibits governance recovery of the configured payment token
- records evidence and approval references as hashes rather than sensitive payloads
- adds Foundry unit, fuzz, and invariant coverage
- adds a path-scoped GitHub Actions validation workflow
- documents PowerShell installation, testing, evidence, and deployment gates

## Why

SKYGRID needs a controlled way to accept pilot funding and convert verified delivery into auditable operating revenue without issuing a speculative token or coupling financial execution to the Emergency Data On-Ramp.

## Security posture

The intended production configuration uses Safe multisignature addresses for governance, milestone approval, beneficiary treasury, and platform treasury. The default commercial model can use a disclosed 350-basis-point platform fee, while the contract enforces a 1,000-basis-point hard ceiling.

No production deployment, private key, live treasury address, or real stablecoin address is included.

## Validation

The workflow installs pinned OpenZeppelin Contracts v5.4.0 and forge-std v1.10.0, checks `forge fmt`, and runs unit, fuzz, and invariant tests with Solidity 0.8.24.