### PR TITLE
Fix SKYGRID preflight for Vercel 402 protection gate

### DIFF
--- a/scripts/test-skygrid-routing-success.mjs
+++ b/scripts/test-skygrid-routing-success.mjs
@@ -8,49 +8,49 @@ const checks = [
     method: "GET",
     path: "/",
     success: [200, 202, 204, 301, 302, 307, 308],
-    pending: [401, 403, 404]
+    pending: [401, 402, 403, 404]
   },
   {
     name: "Static health contract",
     method: "GET",
     path: "/health.json",
     success: [200, 202, 204, 301, 302, 307, 308],
-    pending: [401, 403, 404]
+    pending: [401, 402, 403, 404]
   },
   {
     name: "Dispatcher route",
     method: "GET",
     path: "/dispatch",
     success: [200, 202, 204, 301, 302, 307, 308, 405],
-    pending: [401, 403, 404]
+    pending: [401, 402, 403, 404]
   },
   {
     name: "Scenario route",
     method: "GET",
     path: "/scenarios",
     success: [200, 202, 204, 301, 302, 307, 308, 405],
-    pending: [401, 403, 404]
+    pending: [401, 402, 403, 404]
   },
   {
     name: "SKYGRID status API",
     method: "GET",
     path: "/api/skygrid/status",
     success: [200, 202, 204, 301, 302, 307, 308, 405],
-    pending: [401, 403, 404]
+    pending: [401, 402, 403, 404]
   },
   {
     name: "Highway status API",
     method: "GET",
     path: "/api/highway/status",
     success: [200, 202, 204, 301, 302, 307, 308, 405],
-    pending: [401, 403, 404]
+    pending: [401, 402, 403, 404]
   },
   {
     name: "SKYGRID intake POST",
     method: "POST",
     path: "/api/skygrid/intake",
     success: [200, 201, 202, 204, 405],
-    pending: [401, 403, 404],
+    pending: [401, 402, 403, 404],
     body: {
       system: "SKYGRID Emergency Data On-Ramp",
       control_layer: "Aura-Core AI",

--- a/scripts/verify-skygrid-routes.mjs
+++ b/scripts/verify-skygrid-routes.mjs
@@ -24,7 +24,7 @@ const checks = [
 ];
 
 const okStatuses = new Set([200, 202, 204, 301, 302, 307, 308, 405]);
-const pendingStatuses = new Set([401, 403, 404]);
+const pendingStatuses = new Set([401, 402, 403, 404]);
 
 let failed = false;
 let pending = false;


### PR DESCRIPTION
Closed as superseded by #144. PR #144 contains the same HTTP 402 pending-route classification and additionally enforces the intended safety boundary: pending/protected responses are non-blocking only when SKYGRID_ALLOW_PENDING_DOMAIN=true; otherwise the verifier fails.