### PR TITLE
Harden SKYGRID local command-center tooling

### DIFF
--- a/.github/workflows/skygrid-command-center-ci.yml
+++ b/.github/workflows/skygrid-command-center-ci.yml
@@ -1,0 +1,52 @@
+name: SKYGRID Command Center Validation
+
+on:
+  pull_request:
+    paths:
+      - "Aura/Skills/LocalRouteScanner.ps1"
+      - "restart-skygrid-dual-lane.ps1"
+      - "scripts/skygrid-iphone-debug-server.mjs"
+      - "tests/CommandCenter.Tests.ps1"
+      - ".github/workflows/skygrid-command-center-ci.yml"
+      - "SECURITY.md"
+  push:
+    branches:
+      - MVPuknowme
+    paths:
+      - "Aura/Skills/LocalRouteScanner.ps1"
+      - "restart-skygrid-dual-lane.ps1"
+      - "scripts/skygrid-iphone-debug-server.mjs"
+      - "tests/CommandCenter.Tests.ps1"
+      - ".github/workflows/skygrid-command-center-ci.yml"
+      - "SECURITY.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  powershell-safety:
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate PowerShell command-center controls
+        shell: pwsh
+        run: ./tests/CommandCenter.Tests.ps1
+
+  node-syntax:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Validate guarded debug server
+        run: node --check scripts/skygrid-iphone-debug-server.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ xcuserdata/
 .skygrid/ethereum-collection-drafts/
 .skygrid/
 
+# SKYGRID local runtime process state
+.skygrid-runtime.pid
+.skygrid-runtime.log
+.skygrid-runtime-error.log
+
 .env.local
 desktop-gpt/.runtime/
 desktop-gpt/logs/

--- a/Aura/Skills/LocalRouteScanner.ps1
+++ b/Aura/Skills/LocalRouteScanner.ps1
@@ -1,0 +1,539 @@
+[CmdletBinding()]
+param(
+    [string]$RepoPath,
+    [string[]]$AllowedHosts,
+    [ValidateRange(1, 65535)][int[]]$PortsToTest = @(3000),
+    [string[]]$HealthPaths = @(
+        "/api/health",
+        "/health.json",
+        "/api/skygrid/status",
+        "/api/highway/status"
+    ),
+    [ValidateRange(1, 10)][int]$ProbeCount = 3,
+    [ValidateRange(1, 30)][int]$TimeoutSeconds = 3,
+    [ValidateRange(0, 100)][double]$SwitchImprovementPercent = 20,
+    [ValidateRange(1, 10)][int]$SwitchConfirmations = 2,
+    [ValidateRange(0, 3600)][int]$SwitchCooldownSeconds = 60,
+    [string]$ExpectedVersion,
+    [switch]$IncludeVirtualAdapters,
+    [switch]$NoStateWrite
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$Product = "SKYGRID Emergency Data On-Ramp"
+$RuntimeName = "vercel-aura-core"
+$Mode = "controlled-pilot"
+$Sentinel = "fail_closed"
+
+function Get-PropertyValue {
+    param($InputObject, [Parameter(Mandatory)][string]$Name)
+
+    if ($null -eq $InputObject) { return $null }
+    $Property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $Property) { return $null }
+    return $Property.Value
+}
+
+function Resolve-RepoPath {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        if ([string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+            throw "Repository path was not supplied and PSScriptRoot is unavailable."
+        }
+        $Path = Join-Path $PSScriptRoot "..\.."
+    }
+
+    $Resolved = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path -LiteralPath (Join-Path $Resolved ".git"))) {
+        throw "Aura-Core repository not found at: $Resolved"
+    }
+    return $Resolved
+}
+
+function Write-JsonUtf8 {
+    param($Value, [string]$Path, [int]$Depth = 16)
+
+    $Json = $Value | ConvertTo-Json -Depth $Depth
+    $Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($Path, $Json + "`n", $Utf8NoBom)
+}
+
+function Read-JsonSafe {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    try {
+        return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    }
+    catch {
+        Write-Warning "Ignoring unreadable route state: $Path"
+        return $null
+    }
+}
+
+function Convert-BytesToHex {
+    param([byte[]]$Bytes)
+    return (($Bytes | ForEach-Object { $_.ToString("x2") }) -join "")
+}
+
+function Get-Sha256Hex {
+    param([string]$Text)
+
+    $Algorithm = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $Bytes = [System.Text.Encoding]::UTF8.GetBytes($Text)
+        return Convert-BytesToHex -Bytes ($Algorithm.ComputeHash($Bytes))
+    }
+    finally {
+        $Algorithm.Dispose()
+    }
+}
+
+function Get-HmacSha256Hex {
+    param([string]$Text, [string]$Secret)
+
+    $Key = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+    $Data = [System.Text.Encoding]::UTF8.GetBytes($Text)
+    $Algorithm = [System.Security.Cryptography.HMACSHA256]::new($Key)
+    try {
+        return Convert-BytesToHex -Bytes ($Algorithm.ComputeHash($Data))
+    }
+    finally {
+        $Algorithm.Dispose()
+    }
+}
+
+function Get-Median {
+    param([double[]]$Values)
+
+    if (-not $Values -or $Values.Count -eq 0) { return $null }
+    $Sorted = @($Values | Sort-Object)
+    $Middle = [math]::Floor($Sorted.Count / 2)
+    if ($Sorted.Count % 2 -eq 1) { return [double]$Sorted[$Middle] }
+    return ([double]$Sorted[$Middle - 1] + [double]$Sorted[$Middle]) / 2
+}
+
+function Test-IsVirtualAdapter {
+    param([string]$Text)
+    return $Text -match '(?i)(loopback|docker|hyper-v|vethernet|virtual|vmware|vpn|tunnel|tailscale|wireguard|wsl|bluetooth)'
+}
+
+function Get-AdapterSnapshot {
+    param([switch]$AllowVirtual)
+
+    $Snapshots = foreach ($Route in @(
+        Get-NetRoute -AddressFamily IPv4 -DestinationPrefix "0.0.0.0/0" -ErrorAction SilentlyContinue
+    )) {
+        $Adapter = Get-NetAdapter -InterfaceIndex $Route.InterfaceIndex -ErrorAction SilentlyContinue
+        if (-not $Adapter -or $Adapter.Status -ne "Up") { continue }
+
+        $AdapterIdentity = "$($Adapter.Name) $($Adapter.InterfaceDescription)"
+        if (-not $AllowVirtual -and (Test-IsVirtualAdapter $AdapterIdentity)) { continue }
+
+        $IpInterface = Get-NetIPInterface -AddressFamily IPv4 -InterfaceIndex $Route.InterfaceIndex -ErrorAction SilentlyContinue
+        $Address = Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $Route.InterfaceIndex -ErrorAction SilentlyContinue |
+            Where-Object { $_.IPAddress -ne "127.0.0.1" -and $_.IPAddress -notlike "169.254.*" } |
+            Select-Object -First 1
+        $Config = Get-NetIPConfiguration -InterfaceIndex $Route.InterfaceIndex -ErrorAction SilentlyContinue
+
+        $InterfaceMetric = if ($IpInterface) { [int]$IpInterface.InterfaceMetric } else { 0 }
+        $TotalMetric = [int]$Route.RouteMetric + $InterfaceMetric
+        $LinkSpeedMbps = 0.0
+        try { $LinkSpeedMbps = [math]::Round(([double]$Adapter.LinkSpeed / 1000000), 2) } catch {}
+        $AdapterScore = [math]::Round(
+            1000 - [math]::Min(900, $TotalMetric) +
+            [math]::Min(100, [math]::Log10($LinkSpeedMbps + 1) * 25),
+            2
+        )
+
+        [pscustomobject]@{
+            interface_index  = [int]$Route.InterfaceIndex
+            interface_alias  = [string]$Adapter.Name
+            description      = [string]$Adapter.InterfaceDescription
+            ipv4_address     = if ($Address) { [string]$Address.IPAddress } else { $null }
+            gateway          = if ($Config -and $Config.IPv4DefaultGateway) {
+                [string]$Config.IPv4DefaultGateway.NextHop
+            } else { $null }
+            dns_servers      = if ($Config -and $Config.DnsServer) {
+                @($Config.DnsServer.ServerAddresses)
+            } else { @() }
+            route_metric     = [int]$Route.RouteMetric
+            interface_metric = $InterfaceMetric
+            total_metric     = $TotalMetric
+            link_speed_mbps  = $LinkSpeedMbps
+            adapter_score    = $AdapterScore
+        }
+    }
+
+    return @($Snapshots | Sort-Object total_metric, @{ Expression = "adapter_score"; Descending = $true })
+}
+
+function Test-SkygridIdentity {
+    param($Response, [string]$RequestedPath, [string]$RequiredVersion)
+
+    $Reasons = [System.Collections.Generic.List[string]]::new()
+    $Payload = $null
+    try { $Payload = [string]$Response.Content | ConvertFrom-Json }
+    catch { $Reasons.Add("response_not_valid_json") }
+
+    $HeaderProduct = [string]$Response.Headers["X-SKYGRID-Product"]
+    $HeaderRuntime = [string]$Response.Headers["X-SKYGRID-Runtime"]
+    $ContentType = [string]$Response.Headers["Content-Type"]
+
+    if ([int]$Response.StatusCode -lt 200 -or [int]$Response.StatusCode -ge 300) { $Reasons.Add("unexpected_status_code") }
+    if ($ContentType -notmatch '(?i)^application/json(?:;|$)') { $Reasons.Add("unexpected_content_type") }
+    if ($HeaderProduct -ne $Product) { $Reasons.Add("product_header_mismatch") }
+    if ([string]::IsNullOrWhiteSpace($HeaderRuntime)) { $Reasons.Add("runtime_header_missing") }
+
+    $PayloadOk = Get-PropertyValue $Payload "ok"
+    $PayloadProduct = [string](Get-PropertyValue $Payload "product")
+    $PayloadSkygrid = [string](Get-PropertyValue $Payload "skygrid")
+    $PayloadRuntime = [string](Get-PropertyValue $Payload "runtime")
+    $PayloadMode = [string](Get-PropertyValue $Payload "mode")
+    $PayloadSentinel = [string](Get-PropertyValue $Payload "sentinel")
+    $PayloadRoute = [string](Get-PropertyValue $Payload "route")
+    $PayloadVersion = [string](Get-PropertyValue $Payload "version")
+
+    if ($Payload) {
+        if ($PayloadOk -ne $true) { $Reasons.Add("payload_ok_not_true") }
+        if ($PayloadProduct -ne $Product) { $Reasons.Add("payload_product_mismatch") }
+        if ($PayloadSkygrid -ne $Product) { $Reasons.Add("payload_skygrid_mismatch") }
+        if ($PayloadRuntime -ne $RuntimeName) { $Reasons.Add("payload_runtime_mismatch") }
+        if ($PayloadMode -ne $Mode) { $Reasons.Add("payload_mode_mismatch") }
+        if ($PayloadSentinel -ne $Sentinel) { $Reasons.Add("payload_sentinel_mismatch") }
+        if ($PayloadRoute -ne $RequestedPath) { $Reasons.Add("payload_route_mismatch") }
+        if ([string]::IsNullOrWhiteSpace($PayloadVersion)) { $Reasons.Add("payload_version_missing") }
+        elseif ($PayloadVersion -ne $HeaderRuntime) { $Reasons.Add("header_payload_version_mismatch") }
+        if ($RequiredVersion -and $PayloadVersion -ne $RequiredVersion) { $Reasons.Add("required_version_mismatch") }
+    }
+
+    return [pscustomobject]@{
+        verified = ($Reasons.Count -eq 0)
+        reasons  = @($Reasons)
+        version  = $PayloadVersion
+    }
+}
+
+function Invoke-SkygridProbe {
+    param(
+        [string]$HostName,
+        [int]$Port,
+        [string]$Path,
+        [int]$Attempts,
+        [int]$Timeout,
+        [string]$RequiredVersion
+    )
+
+    $Uri = "http://${HostName}:$Port$Path"
+    $Samples = @()
+    $MinimumSuccesses = [int][math]::Ceiling($Attempts * 0.67)
+
+    for ($Attempt = 1; $Attempt -le $Attempts; $Attempt++) {
+        $Timer = [System.Diagnostics.Stopwatch]::StartNew()
+        try {
+            $Parameters = @{
+                Uri = $Uri; Method = "Get"; TimeoutSec = $Timeout
+                UseBasicParsing = $true; ErrorAction = "Stop"
+            }
+            if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey("NoProxy")) {
+                $Parameters.NoProxy = $true
+            }
+
+            $Response = Invoke-WebRequest @Parameters
+            $Timer.Stop()
+            $Identity = Test-SkygridIdentity $Response $Path $RequiredVersion
+            $Samples += [pscustomobject]@{
+                attempt = $Attempt
+                latency_ms = [math]::Round($Timer.Elapsed.TotalMilliseconds, 2)
+                status_code = [int]$Response.StatusCode
+                reachable = $true
+                identity_verified = [bool]$Identity.verified
+                identity_reasons = @($Identity.reasons)
+                version = $Identity.version
+                error = $null
+            }
+        }
+        catch {
+            $Timer.Stop()
+            $Samples += [pscustomobject]@{
+                attempt = $Attempt
+                latency_ms = [math]::Round($Timer.Elapsed.TotalMilliseconds, 2)
+                status_code = $null
+                reachable = $false
+                identity_verified = $false
+                identity_reasons = @("request_failed")
+                version = $null
+                error = $_.Exception.Message
+            }
+        }
+    }
+
+    $Verified = @($Samples | Where-Object { $_.reachable -and $_.identity_verified })
+    $Latencies = @($Verified | ForEach-Object { [double]$_.latency_ms })
+    $Median = Get-Median $Latencies
+    $Jitter = if ($Latencies.Count -gt 1) {
+        [double](($Latencies | Measure-Object -Maximum).Maximum - ($Latencies | Measure-Object -Minimum).Minimum)
+    } elseif ($Latencies.Count -eq 1) { 0.0 } else { $null }
+    $Healthy = $Verified.Count -ge $MinimumSuccesses
+    $Score = if ($Healthy) {
+        [math]::Round([double]$Median + ([double]$Jitter * 2) + (($Attempts - $Verified.Count) * 1000), 2)
+    } else { $null }
+
+    return [pscustomobject]@{
+        uri = $Uri
+        base_url = "http://${HostName}:$Port"
+        route_key = "http://${HostName}:$Port"
+        host = $HostName
+        port = $Port
+        path = $Path
+        attempts = $Attempts
+        verified_successes = $Verified.Count
+        minimum_successes = $MinimumSuccesses
+        median_latency_ms = if ($null -ne $Median) { [math]::Round([double]$Median, 2) } else { $null }
+        jitter_ms = if ($null -ne $Jitter) { [math]::Round([double]$Jitter, 2) } else { $null }
+        route_score = $Score
+        identity_verified = ($Verified.Count -gt 0)
+        healthy = $Healthy
+        version = if ($Verified.Count -gt 0) { [string]$Verified[0].version } else { $null }
+        samples = @($Samples)
+    }
+}
+
+$RepoPath = Resolve-RepoPath $RepoPath
+$StateDir = Join-Path $RepoPath "Aura\State"
+$ReceiptDir = Join-Path $StateDir "RouteReceipts"
+$StateFile = Join-Path $StateDir "active-route.json"
+
+$Adapters = @(Get-AdapterSnapshot -AllowVirtual:$IncludeVirtualAdapters)
+$DefaultAdapter = $Adapters | Select-Object -First 1
+
+if (-not $AllowedHosts -or $AllowedHosts.Count -eq 0) {
+    $AllowedHosts = @("127.0.0.1", "host.docker.internal")
+    if ($DefaultAdapter -and $DefaultAdapter.ipv4_address) {
+        $AllowedHosts += [string]$DefaultAdapter.ipv4_address
+    }
+}
+$AllowedHosts = @($AllowedHosts | Where-Object { $_ } | Select-Object -Unique)
+if ($AllowedHosts.Count -eq 0) { throw "At least one explicitly allowed host is required." }
+
+foreach ($HostName in $AllowedHosts) {
+    if ($HostName -notmatch '^[A-Za-z0-9.-]+$') { throw "Invalid allowed host: $HostName" }
+}
+foreach ($Path in $HealthPaths) {
+    if ($Path -notmatch '^/[A-Za-z0-9._~!$&''()*+,;=:@%/-]+$') { throw "Invalid health path: $Path" }
+}
+
+$Results = foreach ($HostName in $AllowedHosts) {
+    foreach ($Port in $PortsToTest) {
+        foreach ($Path in $HealthPaths) {
+            Invoke-SkygridProbe $HostName $Port $Path $ProbeCount $TimeoutSeconds $ExpectedVersion
+        }
+    }
+}
+
+$Results |
+    Sort-Object @{ Expression = "healthy"; Descending = $true }, @{ Expression = "route_score"; Ascending = $true } |
+    Format-Table -Property uri, verified_successes, median_latency_ms, jitter_ms, identity_verified, healthy, route_score -AutoSize
+
+$HealthyLanes = @(
+    $Results | Where-Object healthy |
+    Sort-Object @{ Expression = "route_score"; Ascending = $true }, @{ Expression = "median_latency_ms"; Ascending = $true }
+)
+$BestLane = $HealthyLanes | Select-Object -First 1
+$PreviousState = Read-JsonSafe $StateFile
+$PreviousSelectedRoute = Get-PropertyValue $PreviousState "selected_route"
+
+if (-not $PreviousSelectedRoute -and $PreviousState) {
+    $LegacyUrl = [string](Get-PropertyValue $PreviousState "url")
+    $LegacyPath = [string](Get-PropertyValue $PreviousState "health_endpoint")
+    if ($LegacyUrl -and $LegacyPath) {
+        $PreviousSelectedRoute = [pscustomobject]@{
+            route_key = $LegacyUrl
+            base_url = $LegacyUrl
+            health_endpoint = $LegacyPath
+        }
+    }
+}
+
+$PreviousRouteKey = [string](Get-PropertyValue $PreviousSelectedRoute "route_key")
+$PreviousLane = if ($PreviousRouteKey) {
+    $HealthyLanes | Where-Object route_key -eq $PreviousRouteKey | Select-Object -First 1
+} else { $null }
+
+$Now = [datetimeoffset]::UtcNow
+$Decision = "FAIL_CLOSED"
+$Reason = "no_verified_lane"
+$SelectedLane = $null
+$PendingCandidate = $null
+$ImprovementPercent = $null
+
+if ($BestLane) {
+    if (-not $PreviousSelectedRoute) {
+        $Decision = "SELECT"; $Reason = "first_verified_lane"; $SelectedLane = $BestLane
+    }
+    elseif (-not $PreviousLane) {
+        $Decision = "SWITCH"; $Reason = "previous_lane_not_verified"; $SelectedLane = $BestLane
+    }
+    elseif ($PreviousLane.route_key -eq $BestLane.route_key) {
+        $Decision = "RETAIN"; $Reason = "current_lane_remains_best"; $SelectedLane = $PreviousLane
+    }
+    else {
+        $PreviousLatency = [double]$PreviousLane.median_latency_ms
+        $CandidateLatency = [double]$BestLane.median_latency_ms
+        $ImprovementPercent = if ($PreviousLatency -gt 0) {
+            [math]::Round((($PreviousLatency - $CandidateLatency) / $PreviousLatency) * 100, 2)
+        } else { 0.0 }
+
+        $SelectedAtText = [string](Get-PropertyValue $PreviousState "selected_at")
+        $SelectedAt = [datetimeoffset]::MinValue
+        if (-not [datetimeoffset]::TryParse($SelectedAtText, [ref]$SelectedAt)) {
+            $SelectedAt = [datetimeoffset]::MinValue
+        }
+        $CooldownElapsed = ($Now - $SelectedAt).TotalSeconds -ge $SwitchCooldownSeconds
+
+        $PreviousCandidate = Get-PropertyValue $PreviousState "pending_candidate"
+        $PreviousCandidateKey = [string](Get-PropertyValue $PreviousCandidate "route_key")
+        $PreviousConfirmations = Get-PropertyValue $PreviousCandidate "confirmations"
+        $Confirmations = if ($PreviousCandidateKey -eq $BestLane.route_key) {
+            [int]$PreviousConfirmations + 1
+        } else { 1 }
+
+        $PendingCandidate = [ordered]@{
+            route_key = $BestLane.route_key
+            base_url = $BestLane.base_url
+            health_endpoint = $BestLane.path
+            confirmations = $Confirmations
+            observed_at = $Now.ToString("o")
+            improvement_percent = $ImprovementPercent
+        }
+
+        $ImprovementMet = $ImprovementPercent -ge $SwitchImprovementPercent
+        $ConfirmationsMet = $Confirmations -ge $SwitchConfirmations
+
+        if ($ImprovementMet -and $ConfirmationsMet -and $CooldownElapsed) {
+            $Decision = "SWITCH"; $Reason = "candidate_confirmed_and_materially_better"
+            $SelectedLane = $BestLane; $PendingCandidate = $null
+        }
+        else {
+            $Decision = "RETAIN"; $SelectedLane = $PreviousLane
+            if (-not $ImprovementMet) { $Reason = "candidate_improvement_below_threshold" }
+            elseif (-not $ConfirmationsMet) { $Reason = "candidate_waiting_for_confirmation" }
+            else { $Reason = "switch_cooldown_active" }
+        }
+    }
+}
+
+$ObservedAt = $Now.ToString("o")
+$DecisionId = [guid]::NewGuid().ToString("n")
+$ReceiptPath = Join-Path $ReceiptDir "route-decision-$($Now.ToString('yyyyMMddTHHmmssfffZ'))-$DecisionId.json"
+$SelectedRoute = if ($SelectedLane) {
+    [ordered]@{
+        route_key = $SelectedLane.route_key
+        base_url = $SelectedLane.base_url
+        health_endpoint = $SelectedLane.path
+        median_latency_ms = $SelectedLane.median_latency_ms
+        jitter_ms = $SelectedLane.jitter_ms
+        route_score = $SelectedLane.route_score
+        version = $SelectedLane.version
+        identity_verified = $SelectedLane.identity_verified
+    }
+} else { $null }
+
+$ReceiptCore = [ordered]@{
+    schema = "skygrid.route-decision-receipt.v1"
+    decision_id = $DecisionId
+    observed_at = $ObservedAt
+    product = $Product
+    mode = $Mode
+    sentinel = $Sentinel
+    decision = $Decision
+    reason = $Reason
+    improvement_percent = $ImprovementPercent
+    thresholds = [ordered]@{
+        probe_count = $ProbeCount
+        timeout_seconds = $TimeoutSeconds
+        switch_improvement_percent = $SwitchImprovementPercent
+        switch_confirmations = $SwitchConfirmations
+        switch_cooldown_seconds = $SwitchCooldownSeconds
+    }
+    allowed_scope = [ordered]@{
+        hosts = @($AllowedHosts)
+        ports = @($PortsToTest)
+        paths = @($HealthPaths)
+    }
+    default_adapter = $DefaultAdapter
+    adapters = @($Adapters)
+    previous_route = $PreviousSelectedRoute
+    selected_route = $SelectedRoute
+    pending_candidate = $PendingCandidate
+    probes = @($Results)
+}
+
+$CanonicalReceipt = $ReceiptCore | ConvertTo-Json -Depth 16 -Compress
+$ReceiptHash = Get-Sha256Hex $CanonicalReceipt
+$HmacSecret = [string]$env:SKYGRID_ROUTE_RECEIPT_HMAC_KEY
+$Integrity = [ordered]@{
+    hash_algorithm = "SHA-256"
+    sha256 = $ReceiptHash
+    signature_algorithm = if ($HmacSecret) { "HMAC-SHA256" } else { $null }
+    signature = if ($HmacSecret) { Get-HmacSha256Hex $CanonicalReceipt $HmacSecret } else { $null }
+}
+
+$Receipt = [ordered]@{}
+foreach ($Entry in $ReceiptCore.GetEnumerator()) { $Receipt[$Entry.Key] = $Entry.Value }
+$Receipt.integrity = $Integrity
+
+$PreviousSelectedAt = [string](Get-PropertyValue $PreviousState "selected_at")
+$SelectedAtOutput = if ($Decision -in @("SELECT", "SWITCH") -or -not $PreviousSelectedAt) {
+    $ObservedAt
+} else { $PreviousSelectedAt }
+
+$State = [ordered]@{
+    schema = "skygrid.route-state.v2"
+    checked_at = $ObservedAt
+    selected_at = $SelectedAtOutput
+    state = if ($SelectedLane) { "HEALTHY" } else { "OFFLINE" }
+    decision = $Decision
+    reason = $Reason
+    selected_route = $SelectedRoute
+    pending_candidate = $PendingCandidate
+    receipt_file = $ReceiptPath
+    receipt_sha256 = $ReceiptHash
+    action = if ($SelectedLane) {
+        "Route verified. Continue controlled-pilot traffic."
+    } else {
+        "Fail closed and retain traffic in the durable queue."
+    }
+}
+
+if (-not $NoStateWrite) {
+    New-Item -ItemType Directory -Path $ReceiptDir -Force | Out-Null
+    Write-JsonUtf8 $Receipt $ReceiptPath 18
+    Write-JsonUtf8 $State $StateFile 10
+}
+
+Write-Host ""
+if ($SelectedLane) {
+    Write-Host "SKYGRID VERIFIED LANE: $Decision" -ForegroundColor Green
+    Write-Host "URL:       $($SelectedLane.base_url)"
+    Write-Host "Health:    $($SelectedLane.path)"
+    Write-Host "Median:    $($SelectedLane.median_latency_ms) ms"
+    Write-Host "Jitter:    $($SelectedLane.jitter_ms) ms"
+    Write-Host "Reason:    $Reason"
+}
+else {
+    Write-Host "NO VERIFIED SKYGRID LANE - FAIL CLOSED" -ForegroundColor Yellow
+    Write-Host "Reason: $Reason"
+}
+
+if ($NoStateWrite) {
+    Write-Host "Dry run: no state or receipt files were written."
+}
+else {
+    Write-Host "State:     $StateFile"
+    Write-Host "Receipt:   $ReceiptPath"
+    Write-Host "SHA-256:   $ReceiptHash"
+}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,158 @@
+# Security Policy
+
+## Purpose
+
+This policy explains how to report security vulnerabilities affecting the **SKYGRID Emergency Data On-Ramp** and related Aura-Core components.
+
+SKYGRID is designed as a controlled, operator-gated, fail-closed continuity system. Security defects may affect intake validation, routing decisions, receipt integrity, authentication, authorization, availability, or submitted data.
+
+This policy does not create a warranty, service-level agreement, regulatory certification, or guarantee of payment.
+
+## Supported Versions
+
+Security fixes are prioritized for:
+
+- The actively maintained default branch
+- The latest tagged controlled-pilot release
+
+Older releases, archived prototypes, forks, and third-party modifications are supported only on a best-effort basis.
+
+## Reporting a Vulnerability
+
+Do not open a public GitHub issue for a suspected vulnerability.
+
+Report vulnerabilities privately to:
+
+**mvpuknowme@skygrid-protocol.net**
+
+Email subject:
+
+**[SECURITY] SKYGRID vulnerability report**
+
+Include:
+
+- Affected component, endpoint, release, or commit
+- Vulnerability type and expected impact
+- Reproduction steps or proof of concept
+- Required access, credentials, or network position
+- Relevant sanitized logs, requests, responses, or receipt identifiers
+- Suggested remediation, when known
+- Your preferred contact information
+
+Do not send private keys, seed phrases, passwords, live tokens, patient data, financial data, or unrelated third-party information.
+
+## Emergency Notice
+
+This repository and mailbox are not emergency dispatch channels.
+
+For an active threat to life or property, contact the appropriate local emergency service.
+
+For an active compromise of a SKYGRID-controlled environment, include **ACTIVE INCIDENT** in the email subject and identify:
+
+- The affected environment
+- Time first observed, including time zone
+- Known indicators of compromise
+- Actions already taken
+- Whether credentials or sensitive data may be exposed
+
+## Response Targets
+
+These are operational targets, not contractual guarantees:
+
+| Stage | Target |
+|---|---|
+| Initial acknowledgment | Within 3 business days |
+| Preliminary triage | Within 7 business days |
+| Severity assessment | Within 10 business days |
+| High or critical remediation plan | As soon as practical after validation |
+
+## High-Impact Findings
+
+Examples include:
+
+- Authentication or authorization bypass
+- Remote code execution
+- Exposure of credentials, private keys, signing secrets, or sensitive data
+- Forged, altered, deleted, or replayed decision receipts
+- Impersonation of a verified SKYGRID runtime
+- Bypass of fail-closed or operator-approval controls
+- Unauthorized production failover or emergency dispatch
+- Unauthorized wallet signing, transaction broadcasting, or payment execution
+- Cross-tenant access
+- Durable denial of service
+- Compromise of build or artifact provenance
+
+## SKYGRID Security Boundaries
+
+Unless explicitly authorized for a specific deployment:
+
+- Routing decisions remain advisory or operator-gated.
+- Production failover is not autonomous.
+- Emergency dispatch is not autonomous.
+- Wallet signing and transaction broadcasting are prohibited.
+- Payment execution is prohibited.
+- Private-data movement outside approved routes is prohibited.
+- Generic successful health responses do not establish trusted identity.
+- Product, runtime, mode, sentinel, route, headers, and version must be validated.
+- Decision and intake receipts should be integrity-protected.
+
+A demonstrated bypass of these boundaries is in scope.
+
+## Permitted Research
+
+Good-faith research may include:
+
+- Testing repository code in an isolated environment
+- Reviewing validation, authorization, routing, and receipt logic
+- Testing documented public endpoints at low request volume
+- Reviewing dependencies and infrastructure configuration
+- Using synthetic data and accounts you control
+
+## Prohibited Testing
+
+Do not:
+
+- Access or modify another party's data
+- Use real patient, financial, emergency, or confidential partner data
+- Perform denial-of-service or destructive testing
+- Disrupt public-safety, healthcare, financial, telecommunications, cloud, or partner systems
+- Conduct phishing, extortion, social engineering, or credential theft
+- Deploy malware, ransomware, persistence, or surveillance tooling
+- Test systems you do not own or lack permission to assess
+- Publicly disclose an unremediated vulnerability prematurely
+
+Stop testing immediately if sensitive data, unintended privileged access, or service disruption occurs.
+
+## Safe Harbor
+
+The project will not pursue legal action solely for good-faith research that follows this policy, avoids privacy violations and disruption, and is reported promptly.
+
+This statement does not authorize testing of third-party systems, excuse unlawful activity, grant access to data, or bind customers, providers, partners, or regulators.
+
+## Secrets
+
+Never commit:
+
+- API or cloud credentials
+- Private keys or seed phrases
+- Signing or HMAC secrets
+- Database or webhook credentials
+- Production environment files
+- Partner access codes
+- Personally identifiable or regulated data
+
+Treat exposed credentials as compromised even when the corresponding commit is later removed.
+
+## Compliance Status
+
+This repository does not independently establish HIPAA, SOC 2, PCI DSS, FedRAMP, StateRAMP, ISO 27001, NIST, CJIS, or other regulatory compliance.
+
+Compliance claims require a defined scope, implemented controls, retained evidence, legal review, and any required independent assessment.
+
+## Contact
+
+Security reports:
+
+**mvpuknowme@skygrid-protocol.net**
+
+Non-security problems may be submitted through the normal GitHub issue process.

--- a/restart-skygrid-dual-lane.ps1
+++ b/restart-skygrid-dual-lane.ps1
@@ -1,0 +1,236 @@
+[CmdletBinding()]
+param(
+    [string]$RepoPath,
+    [string]$WalletAddress,
+    [ValidateRange(1, 65535)][int]$Port = 3000,
+    [ValidateRange(5, 180)][int]$HealthTimeoutSeconds = 60,
+    [switch]$SkipWalletTests,
+    [switch]$NoRouteScan
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Resolve-AuraRepoPath {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $Path = $PSScriptRoot
+    }
+
+    $resolved = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved "package.json"))) {
+        throw "Aura-Core package.json was not found at: $resolved"
+    }
+    return $resolved
+}
+
+function Read-PackageScripts {
+    param([string]$Root)
+
+    $package = Get-Content -LiteralPath (Join-Path $Root "package.json") -Raw |
+        ConvertFrom-Json
+    return $package.scripts
+}
+
+function Assert-RequiredScript {
+    param($Scripts, [string]$Name)
+
+    if ($null -eq $Scripts.PSObject.Properties[$Name]) {
+        throw "Required package script is missing: $Name"
+    }
+}
+
+function Get-RecordedRuntime {
+    param([string]$PidFile, [string]$ExpectedScript)
+
+    if (-not (Test-Path -LiteralPath $PidFile)) { return $null }
+
+    $text = (Get-Content -LiteralPath $PidFile -Raw).Trim()
+    $runtimePid = 0
+    if (-not [int]::TryParse($text, [ref]$runtimePid) -or $runtimePid -le 0) {
+        throw "invalid_runtime_pid_file"
+    }
+
+    $cim = Get-CimInstance Win32_Process -Filter "ProcessId = $runtimePid" -ErrorAction SilentlyContinue
+    if ($null -eq $cim) {
+        Remove-Item -LiteralPath $PidFile -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+
+    $commandLine = [string]$cim.CommandLine
+    $expectedLeaf = [System.IO.Path]::GetFileName($ExpectedScript)
+    if (
+        [string]::IsNullOrWhiteSpace($commandLine) -or
+        $commandLine.IndexOf($expectedLeaf, [System.StringComparison]::OrdinalIgnoreCase) -lt 0
+    ) {
+        throw "recorded_pid_is_not_skygrid_runtime"
+    }
+
+    return Get-Process -Id $runtimePid -ErrorAction Stop
+}
+
+function Stop-RecordedRuntime {
+    param([string]$PidFile, [string]$ExpectedScript)
+
+    $runtime = Get-RecordedRuntime -PidFile $PidFile -ExpectedScript $ExpectedScript
+    if ($null -eq $runtime) { return }
+
+    Write-Host "Stopping recorded SKYGRID runtime PID $($runtime.Id)"
+    Stop-Process -Id $runtime.Id -Force -ErrorAction Stop
+    $runtime.WaitForExit(10000) | Out-Null
+    Remove-Item -LiteralPath $PidFile -Force -ErrorAction SilentlyContinue
+}
+
+function Assert-PortAvailable {
+    param([int]$RequestedPort)
+
+    $listener = Get-NetTCPConnection `
+        -State Listen `
+        -LocalPort $RequestedPort `
+        -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+
+    if ($listener) {
+        throw "port_in_use_by_unmanaged_process:${RequestedPort}:pid=$($listener.OwningProcess)"
+    }
+}
+
+function Invoke-PnpmScript {
+    param([string]$Pnpm, [string]$Root, [string]$Name)
+
+    Write-Host "Running pnpm script: $Name"
+    Push-Location $Root
+    try {
+        & $Pnpm run $Name
+        if ($LASTEXITCODE -ne 0) {
+            throw "pnpm_script_failed:${Name}:$LASTEXITCODE"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$root = Resolve-AuraRepoPath -Path $RepoPath
+$serverScript = Join-Path $root "scripts\skygrid-local-runtime-server.mjs"
+$scannerScript = Join-Path $root "Aura\Skills\LocalRouteScanner.ps1"
+$pidFile = Join-Path $root ".skygrid-runtime.pid"
+$stdout = Join-Path $root ".skygrid-runtime.log"
+$stderr = Join-Path $root ".skygrid-runtime-error.log"
+
+if (-not (Test-Path -LiteralPath $serverScript)) {
+    throw "SKYGRID local runtime server was not found: $serverScript"
+}
+
+if ([string]::IsNullOrWhiteSpace($WalletAddress)) {
+    $WalletAddress = [string]$env:SKYGRID_WALLET_ADDRESS
+}
+if ($WalletAddress -notmatch '^0x[0-9a-fA-F]{40}$') {
+    throw "A valid public EVM wallet address is required. Never provide a seed phrase or private key."
+}
+
+$scripts = Read-PackageScripts -Root $root
+Assert-RequiredScript -Scripts $scripts -Name "local:runtime"
+Assert-RequiredScript -Scripts $scripts -Name "aerodrome:rpc:test"
+Assert-RequiredScript -Scripts $scripts -Name "wallet:dual-lane:test"
+Assert-RequiredScript -Scripts $scripts -Name "wallet:routing:test"
+
+$node = (Get-Command node.exe -ErrorAction Stop).Source
+$pnpm = (Get-Command pnpm.cmd -ErrorAction Stop).Source
+$previousWallet = [string]$env:SKYGRID_WALLET_ADDRESS
+$runtime = $null
+
+try {
+    $env:SKYGRID_WALLET_ADDRESS = $WalletAddress
+
+    Stop-RecordedRuntime -PidFile $pidFile -ExpectedScript $serverScript
+    Assert-PortAvailable -RequestedPort $Port
+
+    if (-not $SkipWalletTests) {
+        Invoke-PnpmScript -Pnpm $pnpm -Root $root -Name "aerodrome:rpc:test"
+        Invoke-PnpmScript -Pnpm $pnpm -Root $root -Name "wallet:dual-lane:test"
+        Invoke-PnpmScript -Pnpm $pnpm -Root $root -Name "wallet:routing:test"
+    }
+
+    Remove-Item $stdout, $stderr -Force -ErrorAction SilentlyContinue
+    $runtime = Start-Process `
+        -FilePath $node `
+        -ArgumentList @($serverScript, "--port", [string]$Port) `
+        -WorkingDirectory $root `
+        -RedirectStandardOutput $stdout `
+        -RedirectStandardError $stderr `
+        -PassThru
+
+    [System.IO.File]::WriteAllText(
+        $pidFile,
+        [string]$runtime.Id + [Environment]::NewLine,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($HealthTimeoutSeconds)
+    $healthUri = "http://127.0.0.1:$Port/api/health"
+    $healthy = $false
+
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        if ($runtime.HasExited) { break }
+        try {
+            $parameters = @{
+                Uri = $healthUri
+                Method = "Get"
+                TimeoutSec = 3
+                UseBasicParsing = $true
+                ErrorAction = "Stop"
+            }
+            if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey("NoProxy")) {
+                $parameters.NoProxy = $true
+            }
+            $response = Invoke-WebRequest @parameters
+            if ([int]$response.StatusCode -eq 200) {
+                $healthy = $true
+                break
+            }
+        }
+        catch {}
+        Start-Sleep -Milliseconds 750
+    }
+
+    if (-not $healthy) {
+        if (Test-Path -LiteralPath $stdout) { Get-Content -LiteralPath $stdout -Tail 100 }
+        if (Test-Path -LiteralPath $stderr) { Get-Content -LiteralPath $stderr -Tail 100 }
+        Stop-RecordedRuntime -PidFile $pidFile -ExpectedScript $serverScript
+        throw "skygrid_runtime_health_check_failed"
+    }
+
+    if (-not $NoRouteScan) {
+        if (-not (Test-Path -LiteralPath $scannerScript)) {
+            throw "LocalRouteScanner was not found: $scannerScript"
+        }
+        & $scannerScript `
+            -RepoPath $root `
+            -AllowedHosts @("127.0.0.1") `
+            -PortsToTest @($Port)
+        if ($LASTEXITCODE -ne 0) {
+            throw "local_route_scanner_failed:$LASTEXITCODE"
+        }
+    }
+
+    [pscustomobject]@{
+        product = "SKYGRID Emergency Data On-Ramp"
+        status = "ready"
+        pid = $runtime.Id
+        pid_file = $pidFile
+        health = $healthUri
+        wallet_address = $WalletAddress
+        process_control = "recorded_pid_only"
+        arbitrary_port_kill = $false
+    }
+}
+finally {
+    if ([string]::IsNullOrWhiteSpace($previousWallet)) {
+        Remove-Item Env:SKYGRID_WALLET_ADDRESS -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:SKYGRID_WALLET_ADDRESS = $previousWallet
+    }
+}

--- a/scripts/skygrid-iphone-debug-server.mjs
+++ b/scripts/skygrid-iphone-debug-server.mjs
@@ -1,0 +1,89 @@
+import { timingSafeEqual } from "node:crypto";
+import express from "express";
+import handler from "./skygrid-local-runtime-router.mjs";
+
+const args = process.argv.slice(2);
+let port = Number(process.env.PORT || 3000);
+let host = process.env.SKYGRID_DEBUG_BIND_HOST || "127.0.0.1";
+let allowLan = false;
+
+for (let index = 0; index < args.length; index += 1) {
+  if (args[index] === "--port" && args[index + 1]) {
+    port = Number(args[index + 1]);
+    index += 1;
+  } else if (args[index] === "--host" && args[index + 1]) {
+    host = args[index + 1];
+    index += 1;
+  } else if (args[index] === "--allow-lan") {
+    allowLan = true;
+  }
+}
+
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  throw new Error("Invalid debug-server port.");
+}
+
+const loopbackHosts = new Set(["127.0.0.1", "localhost", "::1"]);
+const lanBinding = !loopbackHosts.has(host);
+const debugToken = String(process.env.SKYGRID_DEBUG_TOKEN || "");
+
+if (lanBinding && !allowLan) {
+  throw new Error(
+    "Non-loopback binding requires --allow-lan. The default is loopback-only."
+  );
+}
+if (lanBinding && debugToken.length < 24) {
+  throw new Error(
+    "SKYGRID_DEBUG_TOKEN must contain at least 24 characters for LAN debugging."
+  );
+}
+
+function equalToken(actual, expected) {
+  const actualBuffer = Buffer.from(String(actual || ""));
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    actualBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(actualBuffer, expectedBuffer)
+  );
+}
+
+const app = express();
+app.disable("x-powered-by");
+
+app.use((req, res, next) => {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("X-SKYGRID-Debug-Binding", lanBinding ? "lan-guarded" : "loopback");
+
+  if (!lanBinding) return next();
+  if (equalToken(req.headers["x-skygrid-debug-token"], debugToken)) {
+    return next();
+  }
+
+  res.statusCode = 401;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify({
+    ok: false,
+    product: "SKYGRID Emergency Data On-Ramp",
+    error: "debug_token_required"
+  }, null, 2));
+});
+
+app.use((req, res) => {
+  handler(req, res).catch((error) => {
+    res.statusCode = 500;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify({
+      ok: false,
+      product: "SKYGRID Emergency Data On-Ramp",
+      error: "debug_runtime_error",
+      message: String(error?.message || error)
+    }, null, 2));
+  });
+});
+
+app.listen(port, host, () => {
+  const mode = lanBinding ? "LAN access guarded by X-SKYGRID-Debug-Token" : "loopback only";
+  console.log(`SKYGRID debug runtime ready at http://${host}:${port} (${mode})`);
+});

--- a/tests/CommandCenter.Tests.ps1
+++ b/tests/CommandCenter.Tests.ps1
@@ -1,0 +1,82 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")).Path
+$launcher = Join-Path $root "restart-skygrid-dual-lane.ps1"
+$scanner = Join-Path $root "Aura\Skills\LocalRouteScanner.ps1"
+$debugServer = Join-Path $root "scripts\skygrid-iphone-debug-server.mjs"
+
+foreach ($path in @($launcher, $scanner, $debugServer)) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Required command-center file is missing: $path"
+    }
+}
+
+function Assert-PowerShellParses {
+    param([string]$Path)
+
+    $tokens = $null
+    $errors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile(
+        $Path,
+        [ref]$tokens,
+        [ref]$errors
+    ) | Out-Null
+
+    if ($errors.Count -gt 0) {
+        $details = ($errors | ForEach-Object { $_.Message }) -join "; "
+        throw "PowerShell parse failed for ${Path}: $details"
+    }
+}
+
+Assert-PowerShellParses -Path $launcher
+Assert-PowerShellParses -Path $scanner
+
+$launcherText = Get-Content -LiteralPath $launcher -Raw
+$scannerText = Get-Content -LiteralPath $scanner -Raw
+$debugText = Get-Content -LiteralPath $debugServer -Raw
+
+foreach ($required in @(
+    ".skygrid-runtime.pid",
+    "recorded_pid_is_not_skygrid_runtime",
+    "port_in_use_by_unmanaged_process",
+    "Get-RecordedRuntime",
+    "Get-CimInstance Win32_Process",
+    "skygrid-local-runtime-server.mjs",
+    'arbitrary_port_kill = $false'
+)) {
+    if (-not $launcherText.Contains($required)) {
+        throw "Launcher is missing required safety marker: $required"
+    }
+}
+
+$stopCalls = [regex]::Matches($launcherText, "(?im)^\s*Stop-Process\b").Count
+if ($stopCalls -ne 1) {
+    throw "Launcher must contain exactly one process-stop operation inside the verified PID path."
+}
+
+foreach ($required in @(
+    "controlled-pilot",
+    "FAIL_CLOSED",
+    "NoStateWrite",
+    "identity_verified",
+    "SKYGRID_ROUTE_RECEIPT_HMAC_KEY"
+)) {
+    if (-not $scannerText.Contains($required)) {
+        throw "Route scanner is missing required advisory control: $required"
+    }
+}
+
+foreach ($required in @(
+    'host = process.env.SKYGRID_DEBUG_BIND_HOST || "127.0.0.1"',
+    "--allow-lan",
+    "SKYGRID_DEBUG_TOKEN",
+    "x-skygrid-debug-token",
+    "timingSafeEqual"
+)) {
+    if (-not $debugText.Contains($required)) {
+        throw "Debug server is missing required LAN guard: $required"
+    }
+}
+
+Write-Host "SKYGRID command-center safety tests passed."


### PR DESCRIPTION
## What changed

- add a repository security policy for private vulnerability reporting and controlled research
- preserve the advisory `LocalRouteScanner.ps1` with explicit host/port/path allowlists, SKYGRID identity verification, hysteresis, cooldown, and integrity-protected route receipts
- replace the old dual-lane restart script with recorded-PID-only process control
- refuse to terminate or replace an unmanaged process that occupies the requested port
- require the existing mocked Base/Aerodrome, Base/OP, and local-routing tests before startup
- bind the iPhone/debug server to loopback by default
- require both an explicit LAN flag and a long debug token for non-loopback binding
- ignore local runtime PID and log state
- add path-scoped Windows PowerShell and Node.js syntax validation

## Process safety

The launcher stores the PID it creates in `.skygrid-runtime.pid`. On restart, it checks `Win32_Process` and verifies that the recorded command line references the SKYGRID local runtime before stopping it. A stale file is removed; an unrelated PID or unmanaged port listener causes a fail-closed error.

## Network safety

The route scanner measures and records candidate lanes but does not change Windows route tables or interface metrics. The debug server does not listen on LAN interfaces unless `--allow-lan` is supplied and `SKYGRID_DEBUG_TOKEN` contains at least 24 characters.

## Explicit exclusions

- the old absolute-path evidence hash file is not carried forward because its referenced local archive cannot be verified from GitHub
- the old controlled-pilot workflow rewrite is not carried forward because the current workflow already contains the repaired cross-platform training and authentication behavior
- no Vercel project or Vercel configuration is changed

## Validation

- PowerShell parser validation for both command-center scripts
- static assertion that process termination exists only in the recorded/verified PID path
- route-scanner fail-closed and receipt-control markers
- debug-server loopback, LAN opt-in, token, and constant-time comparison markers
- Node.js syntax validation for the debug server

This focused reconstruction supersedes #142.