### PR TITLE
Add verified infrastructure revenue ledger

### DIFF
--- a/api/revenue/dashboard.mjs
+++ b/api/revenue/dashboard.mjs
@@ -1,0 +1,84 @@
+const PRODUCT = "SKYGRID Emergency Data On-Ramp";
+
+export default function handler(req, res) {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-SKYGRID-Product", PRODUCT);
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.statusCode = 200;
+  res.end(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Aura-Core Verified Revenue Ledger</title>
+<style>
+:root{color-scheme:dark;font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;background:#050816;color:#edf6ff}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at top left,#172554,#07101f 42%,#050816)}
+main{max-width:1180px;margin:auto;padding:36px 18px 64px}.panel{background:rgba(12,25,48,.9);border:1px solid rgba(103,232,249,.25);border-radius:24px;padding:24px;box-shadow:0 24px 80px rgba(0,0,0,.34)}
+h1{font-size:clamp(2rem,6vw,4.4rem);line-height:1;margin:.2rem 0 1rem;letter-spacing:-.045em}.badge{display:inline-block;border:1px solid #67e8f9;border-radius:999px;padding:.35rem .7rem;color:#a5f3fc}
+p{color:#cbd5e1;line-height:1.6}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:12px;margin:20px 0}.metric{padding:16px;border:1px solid rgba(255,255,255,.13);border-radius:16px;background:rgba(255,255,255,.045)}.metric span{display:block;color:#94a3b8;font-size:.85rem}.metric strong{font-size:1.5rem}
+textarea{width:100%;min-height:320px;background:#020617;color:#dbeafe;border:1px solid #334155;border-radius:14px;padding:14px;font:13px ui-monospace,SFMono-Regular,Consolas,monospace}button{margin-top:12px;padding:11px 16px;border-radius:999px;border:1px solid #67e8f9;background:#164e63;color:#ecfeff;font-weight:700;cursor:pointer}.notice{border-left:4px solid #f59e0b;padding:12px 14px;background:rgba(245,158,11,.11);border-radius:10px;margin:16px 0}pre{white-space:pre-wrap;background:#020617;border-radius:14px;padding:14px;overflow:auto;color:#bae6fd}a{color:#67e8f9}
+</style>
+</head>
+<body><main><section class="panel">
+<span class="badge">Controlled pilot · evidence-gated</span>
+<h1>Aura-Core Verified Infrastructure Revenue Ledger</h1>
+<p>Submit staking, infrastructure, protocol, treasury, and operating-cost records. Only <strong>verified</strong> or <strong>reconciled</strong> evidence is counted as verified net income.</p>
+<div class="notice"><strong>Safety boundary:</strong> this dashboard does not sign wallets, broadcast transactions, execute payments, or treat estimates as earned income.</div>
+<div class="grid">
+<div class="metric"><span>Verified revenue</span><strong id="revenue">$0.00</strong></div>
+<div class="metric"><span>Verified costs</span><strong id="cost">$0.00</strong></div>
+<div class="metric"><span>Verified net income</span><strong id="net">$0.00</strong></div>
+<div class="metric"><span>Excluded records</span><strong id="excluded">0</strong></div>
+</div>
+<label for="payload"><strong>Ledger request JSON</strong></label>
+<textarea id="payload">{
+  "records": [
+    {
+      "id": "eth_reward_demo",
+      "kind": "revenue",
+      "classification": "staking",
+      "amount_usd": 42.15,
+      "network": "ethereum",
+      "role": "validator",
+      "asset": "ETH",
+      "quantity": 0.012,
+      "evidence_state": "verified",
+      "evidence": { "tx_hash": "0x...", "explorer_url": "https://..." }
+    },
+    {
+      "id": "cloud_cost_demo",
+      "kind": "cost",
+      "classification": "cloud",
+      "amount_usd": 12.00,
+      "network": "skygrid",
+      "role": "runtime",
+      "evidence_state": "reconciled",
+      "evidence": { "invoice_id": "invoice-demo" }
+    }
+  ]
+}</textarea>
+<button id="run">Calculate verified metrics</button>
+<p><a href="/api/revenue/ledger">View API schema</a></p>
+<pre id="output">No calculation run yet.</pre>
+</section></main>
+<script>
+const money = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD'});
+document.getElementById('run').addEventListener('click', async () => {
+  const output = document.getElementById('output');
+  try {
+    const payload = JSON.parse(document.getElementById('payload').value);
+    const response = await fetch('/api/revenue/ledger',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(payload)});
+    const data = await response.json();
+    output.textContent = JSON.stringify(data,null,2);
+    if (!data.ok) return;
+    document.getElementById('revenue').textContent = money.format(data.totals.verified_revenue_usd);
+    document.getElementById('cost').textContent = money.format(data.totals.verified_cost_usd);
+    document.getElementById('net').textContent = money.format(data.totals.verified_net_income_usd);
+    document.getElementById('excluded').textContent = data.record_counts.excluded_from_verified_totals;
+  } catch (error) {
+    output.textContent = String(error);
+  }
+});
+</script></body></html>`);
+}

--- a/api/revenue/ledger.mjs
+++ b/api/revenue/ledger.mjs
@@ -1,0 +1,72 @@
+import { ledgerSchema, summarizeLedger } from "../../lib/verified-revenue-ledger.mjs";
+
+const PRODUCT = "SKYGRID Emergency Data On-Ramp";
+
+function applyHeaders(res) {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("X-SKYGRID-Product", PRODUCT);
+  res.setHeader("X-SKYGRID-Ledger", "verified-infrastructure-revenue");
+}
+
+function send(res, status, payload) {
+  applyHeaders(res);
+  res.statusCode = status;
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+async function readBody(req) {
+  if (req.body && typeof req.body === "object") return req.body;
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+export default async function handler(req, res) {
+  if (req.method === "GET") {
+    return send(res, 200, {
+      ok: true,
+      route: "/api/revenue/ledger",
+      mode: "controlled_pilot",
+      persistence: "request_scoped",
+      schema: ledgerSchema(),
+      safeguards: {
+        no_wallet_signing: true,
+        no_transaction_broadcast: true,
+        no_payment_execution: true
+      },
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "GET, POST");
+    return send(res, 405, {
+      ok: false,
+      error: "method_not_allowed",
+      allowed: ["GET", "POST"]
+    });
+  }
+
+  try {
+    const body = await readBody(req);
+    const result = summarizeLedger(body.records || []);
+    return send(res, 200, {
+      ...result,
+      route: "/api/revenue/ledger",
+      mode: "controlled_pilot",
+      persistence: "request_scoped",
+      warning: "This endpoint calculates and validates submitted records but does not persist them. Connect an approved ledger store before production use."
+    });
+  } catch (error) {
+    return send(res, 400, {
+      ok: false,
+      error: "invalid_ledger_payload",
+      message: error instanceof Error ? error.message : String(error),
+      schema: ledgerSchema(),
+      timestamp: new Date().toISOString()
+    });
+  }
+}

--- a/lib/verified-revenue-ledger.mjs
+++ b/lib/verified-revenue-ledger.mjs
@@ -1,0 +1,207 @@
+const PRODUCT = "SKYGRID Emergency Data On-Ramp";
+
+export const REVENUE_CLASSES = Object.freeze([
+  "staking",
+  "infrastructure",
+  "protocol",
+  "treasury"
+]);
+
+export const COST_CLASSES = Object.freeze([
+  "cloud",
+  "bandwidth",
+  "hardware",
+  "gas",
+  "validator_vote",
+  "protocol_fee",
+  "other"
+]);
+
+export const EVIDENCE_STATES = Object.freeze([
+  "verified",
+  "reconciled",
+  "estimated",
+  "unverified"
+]);
+
+const ACCEPTED_KINDS = new Set(["revenue", "cost"]);
+const ACCEPTED_EVIDENCE = new Set(EVIDENCE_STATES);
+const VERIFIED_STATES = new Set(["verified", "reconciled"]);
+
+function finiteNumber(value, field) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new TypeError(`${field} must be a finite number`);
+  }
+  return number;
+}
+
+function text(value, field) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) throw new TypeError(`${field} is required`);
+  return normalized;
+}
+
+function normalizeEvidence(record) {
+  const state = String(record.evidence_state || "unverified").toLowerCase();
+  if (!ACCEPTED_EVIDENCE.has(state)) {
+    throw new TypeError(`evidence_state must be one of: ${EVIDENCE_STATES.join(", ")}`);
+  }
+
+  const evidence = record.evidence && typeof record.evidence === "object"
+    ? record.evidence
+    : {};
+
+  return {
+    state,
+    tx_hash: evidence.tx_hash ? String(evidence.tx_hash) : null,
+    explorer_url: evidence.explorer_url ? String(evidence.explorer_url) : null,
+    invoice_id: evidence.invoice_id ? String(evidence.invoice_id) : null,
+    contract_id: evidence.contract_id ? String(evidence.contract_id) : null,
+    receipt_hash: evidence.receipt_hash ? String(evidence.receipt_hash) : null,
+    source: evidence.source ? String(evidence.source) : null
+  };
+}
+
+export function normalizeLedgerRecord(record, index = 0) {
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    throw new TypeError(`records[${index}] must be an object`);
+  }
+
+  const kind = String(record.kind || "").toLowerCase();
+  if (!ACCEPTED_KINDS.has(kind)) {
+    throw new TypeError(`records[${index}].kind must be revenue or cost`);
+  }
+
+  const classification = text(record.classification, `records[${index}].classification`).toLowerCase();
+  const allowed = kind === "revenue" ? REVENUE_CLASSES : COST_CLASSES;
+  if (!allowed.includes(classification)) {
+    throw new TypeError(`records[${index}].classification must be one of: ${allowed.join(", ")}`);
+  }
+
+  const amountUsd = finiteNumber(record.amount_usd, `records[${index}].amount_usd`);
+  if (amountUsd < 0) throw new RangeError(`records[${index}].amount_usd cannot be negative`);
+
+  const occurredAt = new Date(record.occurred_at || Date.now());
+  if (Number.isNaN(occurredAt.getTime())) {
+    throw new TypeError(`records[${index}].occurred_at must be a valid date`);
+  }
+
+  const evidence = normalizeEvidence(record);
+
+  return {
+    id: String(record.id || `ledger_${occurredAt.getTime()}_${index}`),
+    kind,
+    classification,
+    amount_usd: Number(amountUsd.toFixed(2)),
+    network: String(record.network || "unspecified").toLowerCase(),
+    role: String(record.role || "unspecified").toLowerCase(),
+    asset: record.asset ? String(record.asset).toUpperCase() : null,
+    quantity: record.quantity == null ? null : finiteNumber(record.quantity, `records[${index}].quantity`),
+    wallet_or_account: record.wallet_or_account ? String(record.wallet_or_account) : null,
+    occurred_at: occurredAt.toISOString(),
+    evidence_state: evidence.state,
+    evidence,
+    notes: record.notes ? String(record.notes) : null
+  };
+}
+
+function add(bucket, key, amount) {
+  bucket[key] = Number(((bucket[key] || 0) + amount).toFixed(2));
+}
+
+export function summarizeLedger(records = []) {
+  if (!Array.isArray(records)) throw new TypeError("records must be an array");
+
+  const normalized = records.map(normalizeLedgerRecord);
+  const totals = {
+    verified_revenue_usd: 0,
+    verified_cost_usd: 0,
+    verified_net_income_usd: 0,
+    estimated_revenue_usd: 0,
+    estimated_cost_usd: 0,
+    unverified_revenue_usd: 0,
+    unverified_cost_usd: 0
+  };
+  const by_classification = {};
+  const by_network = {};
+  const exclusions = [];
+
+  for (const record of normalized) {
+    const verified = VERIFIED_STATES.has(record.evidence_state);
+    const sign = record.kind === "revenue" ? 1 : -1;
+
+    if (verified) {
+      const key = record.kind === "revenue" ? "verified_revenue_usd" : "verified_cost_usd";
+      totals[key] = Number((totals[key] + record.amount_usd).toFixed(2));
+      add(by_classification, record.classification, sign * record.amount_usd);
+      add(by_network, record.network, sign * record.amount_usd);
+    } else if (record.evidence_state === "estimated") {
+      const key = record.kind === "revenue" ? "estimated_revenue_usd" : "estimated_cost_usd";
+      totals[key] = Number((totals[key] + record.amount_usd).toFixed(2));
+      exclusions.push({ id: record.id, reason: "estimated_not_counted_as_verified_income" });
+    } else {
+      const key = record.kind === "revenue" ? "unverified_revenue_usd" : "unverified_cost_usd";
+      totals[key] = Number((totals[key] + record.amount_usd).toFixed(2));
+      exclusions.push({ id: record.id, reason: "unverified_not_counted_as_verified_income" });
+    }
+  }
+
+  totals.verified_net_income_usd = Number(
+    (totals.verified_revenue_usd - totals.verified_cost_usd).toFixed(2)
+  );
+
+  const verifiedCount = normalized.filter((record) => VERIFIED_STATES.has(record.evidence_state)).length;
+
+  return {
+    ok: true,
+    product: PRODUCT,
+    ledger: "Aura-Core Verified Infrastructure Revenue Ledger",
+    accounting_basis: "evidence-gated cash and accrued records",
+    totals,
+    by_classification,
+    by_network,
+    record_counts: {
+      total: normalized.length,
+      verified_or_reconciled: verifiedCount,
+      excluded_from_verified_totals: normalized.length - verifiedCount
+    },
+    exclusions,
+    records: normalized,
+    safeguards: {
+      wallet_signing: false,
+      transaction_broadcast: false,
+      payment_execution: false,
+      estimates_in_verified_income: false
+    },
+    generated_at: new Date().toISOString()
+  };
+}
+
+export function ledgerSchema() {
+  return {
+    product: PRODUCT,
+    ledger: "Aura-Core Verified Infrastructure Revenue Ledger",
+    revenue_classes: REVENUE_CLASSES,
+    cost_classes: COST_CLASSES,
+    evidence_states: EVIDENCE_STATES,
+    required_fields: ["kind", "classification", "amount_usd", "evidence_state"],
+    verified_income_rule: "Only verified or reconciled records are included in verified net income.",
+    example: {
+      id: "eth_reward_2026_07_18_001",
+      kind: "revenue",
+      classification: "staking",
+      amount_usd: 42.15,
+      network: "ethereum",
+      role: "validator",
+      asset: "ETH",
+      quantity: 0.012,
+      occurred_at: "2026-07-18T12:00:00.000Z",
+      evidence_state: "verified",
+      evidence: {
+        tx_hash: "0x...",
+        explorer_url: "https://..."
+      }
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "intake:policy-test": "node --test tests/skygrid-intake-policy.test.mjs",
         "capacity:lease-test": "node --test tests/skygrid-capacity-lease.test.mjs",
         "capacity:lease-verify": "npm run pnpk:validate && npm run capacity:lease-test",
+        "revenue:ledger:test": "node --test tests/verified-revenue-ledger.test.mjs",
         "aura:selection:watch": "node scripts/aura-core-ai-selection-watch.mjs",
         "mcp:check": "node scripts/check-mcp-sdk.mjs",
         "emergency:gate": "node scripts/skygrid-emergency-gate.mjs",

--- a/tests/verified-revenue-ledger.test.mjs
+++ b/tests/verified-revenue-ledger.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ledgerSchema,
+  normalizeLedgerRecord,
+  summarizeLedger
+} from "../lib/verified-revenue-ledger.mjs";
+
+test("counts only verified and reconciled records in verified net income", () => {
+  const result = summarizeLedger([
+    {
+      id: "staking-1",
+      kind: "revenue",
+      classification: "staking",
+      amount_usd: 100,
+      network: "ethereum",
+      evidence_state: "verified",
+      evidence: { tx_hash: "0xabc" }
+    },
+    {
+      id: "rpc-1",
+      kind: "revenue",
+      classification: "infrastructure",
+      amount_usd: 50,
+      network: "skygrid",
+      evidence_state: "estimated"
+    },
+    {
+      id: "cloud-1",
+      kind: "cost",
+      classification: "cloud",
+      amount_usd: 30,
+      network: "skygrid",
+      evidence_state: "reconciled",
+      evidence: { invoice_id: "inv-1" }
+    }
+  ]);
+
+  assert.equal(result.totals.verified_revenue_usd, 100);
+  assert.equal(result.totals.verified_cost_usd, 30);
+  assert.equal(result.totals.verified_net_income_usd, 70);
+  assert.equal(result.totals.estimated_revenue_usd, 50);
+  assert.equal(result.record_counts.excluded_from_verified_totals, 1);
+  assert.equal(result.safeguards.estimates_in_verified_income, false);
+});
+
+test("separates network and classification net values", () => {
+  const result = summarizeLedger([
+    {
+      kind: "revenue",
+      classification: "protocol",
+      amount_usd: 80,
+      network: "scroll",
+      evidence_state: "verified"
+    },
+    {
+      kind: "cost",
+      classification: "gas",
+      amount_usd: 15,
+      network: "scroll",
+      evidence_state: "verified"
+    }
+  ]);
+
+  assert.equal(result.by_network.scroll, 65);
+  assert.equal(result.by_classification.protocol, 80);
+  assert.equal(result.by_classification.gas, -15);
+});
+
+test("rejects negative amounts and unsupported classifications", () => {
+  assert.throws(() => normalizeLedgerRecord({
+    kind: "revenue",
+    classification: "staking",
+    amount_usd: -1,
+    evidence_state: "verified"
+  }), /cannot be negative/);
+
+  assert.throws(() => normalizeLedgerRecord({
+    kind: "revenue",
+    classification: "node_magic",
+    amount_usd: 1,
+    evidence_state: "verified"
+  }), /classification must be one of/);
+});
+
+test("publishes the controlled ledger schema", () => {
+  const schema = ledgerSchema();
+  assert.ok(schema.revenue_classes.includes("staking"));
+  assert.ok(schema.cost_classes.includes("cloud"));
+  assert.match(schema.verified_income_rule, /verified or reconciled/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,7 @@
     { "source": "/dashboard/validation-panel", "destination": "/api/runtime" },
     { "source": "/dashboard/deployment-review", "destination": "/api/runtime" },
     { "source": "/dashboard/receipts", "destination": "/api/runtime" },
+    { "source": "/dashboard/revenue-ledger", "destination": "/api/revenue/dashboard" },
     { "source": "/api/skygrid/status", "destination": "/api/runtime" },
     { "source": "/api/skygrid/intake", "destination": "/api/runtime" },
     { "source": "/api/aura-core/decide", "destination": "/api/runtime" },


### PR DESCRIPTION
## Summary

Implements the Aura-Core Verified Infrastructure Revenue Ledger on the SKYGRID side.

### What changed
- Adds an evidence-gated ledger core for staking, infrastructure, protocol, treasury, and operating-cost records.
- Counts only `verified` and `reconciled` records in verified net income.
- Keeps `estimated` and `unverified` records visible but excluded, with explicit exclusion reasons.
- Adds `GET/POST /api/revenue/ledger` for schema discovery and request-scoped calculations.
- Adds `/dashboard/revenue-ledger` for interactive controlled-pilot calculations.
- Adds Node tests and the `revenue:ledger:test` script.

### Safety boundaries
- No wallet signing.
- No transaction broadcasting.
- No payment execution.
- No persistence yet; API calculations are request-scoped.
- Estimates never enter verified income totals.

### Verification
Run:

```powershell
pnpm run revenue:ledger:test
```

Then exercise the dashboard or post records to `/api/revenue/ledger`.

### Follow-up before production
Connect an approved durable ledger store and authenticated evidence-ingestion path. Keep signing and payment execution outside this service boundary.