### PR TITLE
Add guarded Aura Discord work agent

### DIFF
--- a/.github/workflows/aura-work-agent-ci.yml
+++ b/.github/workflows/aura-work-agent-ci.yml
@@ -62,4 +62,21 @@ jobs:
           exit 1
 
       - name: Build
-        run: pnpm build
+        id: build
+        continue-on-error: true
+        run: pnpm build > build.log 2>&1
+
+      - name: Upload production build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aura-work-agent-build
+          path: apps/aura-work-agent/build.log
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Enforce production build
+        if: steps.build.outcome != 'success'
+        run: |
+          cat build.log
+          exit 1

--- a/.github/workflows/aura-work-agent-ci.yml
+++ b/.github/workflows/aura-work-agent-ci.yml
@@ -42,7 +42,24 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Typecheck
-        run: pnpm typecheck
+        id: typecheck
+        continue-on-error: true
+        run: pnpm typecheck > typecheck.log 2>&1
+
+      - name: Upload TypeScript diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aura-work-agent-typecheck
+          path: apps/aura-work-agent/typecheck.log
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Enforce typecheck
+        if: steps.typecheck.outcome != 'success'
+        run: |
+          cat typecheck.log
+          exit 1
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/aura-work-agent-ci.yml
+++ b/.github/workflows/aura-work-agent-ci.yml
@@ -37,8 +37,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: apps/aura-work-agent/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/aura-work-agent-ci.yml
+++ b/.github/workflows/aura-work-agent-ci.yml
@@ -1,0 +1,50 @@
+name: Aura Work Agent Validation
+
+on:
+  pull_request:
+    paths:
+      - "apps/aura-work-agent/**"
+      - ".github/workflows/aura-work-agent-ci.yml"
+  push:
+    branches:
+      - MVPuknowme
+    paths:
+      - "apps/aura-work-agent/**"
+      - ".github/workflows/aura-work-agent-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: apps/aura-work-agent
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: apps/aura-work-agent/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build

--- a/apps/aura-work-agent/.env.example
+++ b/apps/aura-work-agent/.env.example
@@ -1,0 +1,28 @@
+# Reuse the existing server-side OpenAI key. Never commit the real value.
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-5.4-mini
+
+# Discord application credentials from the Discord Developer Portal.
+DISCORD_APPLICATION_ID=
+DISCORD_PUBLIC_KEY=
+DISCORD_BOT_TOKEN=
+DISCORD_GUILD_ID=
+
+# Comma-separated Discord user IDs permitted to approve GitHub writes.
+DISCORD_OPERATOR_USER_IDS=
+
+# Optional comma-separated Discord role IDs that may mention the bot.
+DISCORD_MENTION_ROLE_IDS=
+
+# Fine-grained GitHub token. Restrict it to selected repositories and required permissions.
+GITHUB_TOKEN=
+GITHUB_ALLOWED_REPOS=MVPuknowme/Aura-core
+
+# Production state. When absent, the app uses in-memory state for local testing only.
+REDIS_URL=
+
+# Protects the optional Vercel Gateway cron endpoint.
+CRON_SECRET=
+
+# SKYGRID health/status endpoint used by /skygrid.
+SKYGRID_STATUS_URL=https://aurcore.skygrid-protocol.net/api/health

--- a/apps/aura-work-agent/README.md
+++ b/apps/aura-work-agent/README.md
@@ -1,0 +1,129 @@
+# Aura Work Agent
+
+Aura Work Agent connects Discord to an OpenAI Agents SDK runtime with narrowly scoped GitHub tools for **SKYGRID Emergency Data On-Ramp** and Aura-Core.
+
+The Discord server invite is for people. Bots cannot accept normal server invitations; the bot must be installed through the Discord Developer Portal using its application install link.
+
+## Capabilities
+
+- `/aura` — general operational assistance
+- `/github` — repository overview, open-issue review, approved issue creation, and approved issue/PR comments
+- `/skygrid` — probes the configured SKYGRID status endpoint
+- Direct messages and `@Aura` mentions through the Discord Gateway
+- Explicit human approval for all GitHub writes
+- Repository allowlist enforced by `GITHUB_ALLOWED_REPOS`
+- Discord operator allowlist enforced by `DISCORD_OPERATOR_USER_IDS`
+
+The first release intentionally does **not** merge pull requests, alter repository settings, change workflow permissions, delete content, or write repository files.
+
+## Approval contract
+
+Read operations may be requested normally:
+
+```text
+/github task: Summarize open issues in MVPuknowme/Aura-core
+```
+
+A write runs only when both conditions are true:
+
+1. The invoking Discord user ID appears in `DISCORD_OPERATOR_USER_IDS`.
+2. The request begins exactly with `APPROVE WRITE:`.
+
+Example:
+
+```text
+/github task: APPROVE WRITE: Create an issue in MVPuknowme/Aura-core titled "Validate Discord agent deployment" with a verification checklist.
+```
+
+The OpenAI Agents SDK pauses sensitive tool calls and the runtime approves them only when those two conditions have already been satisfied.
+
+## 1. Create the Discord application
+
+1. Open the Discord Developer Portal and create an application named **Aura Work Agent**.
+2. On **General Information**, copy the Application ID and Public Key.
+3. On **Bot**, reset/copy the bot token. Treat it as a password.
+4. Enable **Message Content Intent** only when you want normal mentions and direct-message text. Slash commands do not require the Gateway.
+5. Under **Installation**, enable Guild Install with `applications.commands` and `bot` scopes.
+6. Grant only the needed bot permissions: View Channels, Send Messages, Send Messages in Threads, Read Message History, Embed Links, Attach Files, and Add Reactions.
+7. Use Discord's generated installation link to add the application to the work server.
+
+Do not grant Administrator unless a future feature has a documented requirement for it.
+
+## 2. Configure locally
+
+PowerShell:
+
+```powershell
+Set-Location .\apps\aura-work-agent
+Copy-Item .env.example .env.local
+pnpm install
+```
+
+Fill `.env.local` with the existing server-side `OPENAI_API_KEY` and the Discord/GitHub credentials. Never commit `.env.local`.
+
+Recommended GitHub fine-grained token scope:
+
+- Repository access: only `MVPuknowme/Aura-core` and any deliberately added repositories
+- Metadata: read
+- Issues: read and write
+- Pull requests: read and write only if PR comments are required
+- Contents: read-only is sufficient for this release
+
+Add your Discord numeric user ID to `DISCORD_OPERATOR_USER_IDS`. Enable Discord Developer Mode, right-click your user, and choose **Copy User ID**.
+
+## 3. Register slash commands
+
+For immediate testing, set `DISCORD_GUILD_ID` to the numeric server ID. Guild commands update immediately. Leaving it blank registers global commands, which may take longer to propagate.
+
+```powershell
+node --env-file=.env.local .\scripts\register-commands.mjs
+```
+
+## 4. Run locally
+
+```powershell
+pnpm dev
+```
+
+Check:
+
+```powershell
+Invoke-RestMethod http://localhost:3000/api/health
+```
+
+Discord must reach a public HTTPS webhook. For deployed testing, configure the Discord **Interactions Endpoint URL** as:
+
+```text
+https://YOUR-DEPLOYMENT/api/webhooks/discord
+```
+
+## 5. Deploy on Vercel
+
+Create a separate Vercel project from the Aura-Core repository and set its **Root Directory** to:
+
+```text
+apps/aura-work-agent
+```
+
+Add all production environment variables from `.env.example`. Reuse the existing OpenAI key through the `OPENAI_API_KEY` environment variable; do not copy the key into code or Discord.
+
+Set `REDIS_URL` for durable production state. Without Redis, the app intentionally falls back to in-memory state suitable only for local testing and one-shot interactions.
+
+The included nine-minute Gateway cron supports mentions and regular messages on serverless infrastructure. The long-running cron route requires a Vercel plan that supports the configured function duration. Slash commands continue to work through HTTP Interactions even when the Gateway cron is disabled.
+
+After deployment:
+
+1. Set Discord's Interactions Endpoint URL to the production webhook.
+2. Register commands using the production application credentials.
+3. Open `/api/health` and confirm `ok: true`.
+4. Run `/skygrid` and a read-only `/github` request.
+5. Test a write with a harmless issue only after verifying the operator allowlist.
+
+## Security boundaries
+
+- Secrets are environment variables only.
+- Discord requests are signature-verified by the Discord Chat SDK adapter.
+- GitHub repository access is deny-by-default outside `GITHUB_ALLOWED_REPOS`.
+- GitHub writes require the SDK approval interruption plus the local operator gate.
+- The health endpoint reports missing variable names, never values.
+- Responses are truncated for Discord's message limits.

--- a/apps/aura-work-agent/next.config.ts
+++ b/apps/aura-work-agent/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  poweredByHeader: false,
+  output: "standalone",
+};
+
+export default nextConfig;

--- a/apps/aura-work-agent/next.config.ts
+++ b/apps/aura-work-agent/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   output: "standalone",
+  serverExternalPackages: ["zlib-sync"],
 };
 
 export default nextConfig;

--- a/apps/aura-work-agent/package.json
+++ b/apps/aura-work-agent/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@skygrid/aura-work-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.23.0",
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "register:commands": "node scripts/register-commands.mjs"
+  },
+  "dependencies": {
+    "@chat-adapter/discord": "4.33.0",
+    "@chat-adapter/state-memory": "4.33.0",
+    "@chat-adapter/state-redis": "4.33.0",
+    "@openai/agents": "0.13.5",
+    "chat": "4.33.0",
+    "next": "16.2.10",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "zod": "4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "24.1.0",
+    "@types/react": "19.2.2",
+    "@types/react-dom": "19.2.2",
+    "typescript": "5.9.3"
+  }
+}

--- a/apps/aura-work-agent/package.json
+++ b/apps/aura-work-agent/package.json
@@ -25,6 +25,9 @@
     "react-dom": "19.2.0",
     "zod": "4.1.12"
   },
+  "optionalDependencies": {
+    "zlib-sync": "0.1.10"
+  },
   "devDependencies": {
     "@types/node": "24.1.0",
     "@types/react": "19.2.2",

--- a/apps/aura-work-agent/scripts/register-commands.mjs
+++ b/apps/aura-work-agent/scripts/register-commands.mjs
@@ -1,0 +1,76 @@
+const applicationId = process.env.DISCORD_APPLICATION_ID;
+const botToken = process.env.DISCORD_BOT_TOKEN;
+const guildId = process.env.DISCORD_GUILD_ID;
+
+if (!applicationId || !botToken) {
+  console.error("DISCORD_APPLICATION_ID and DISCORD_BOT_TOKEN are required.");
+  process.exit(1);
+}
+
+const commands = [
+  {
+    name: "aura",
+    description: "Ask Aura Work Agent for operational help",
+    type: 1,
+    options: [
+      {
+        name: "prompt",
+        description: "Question or task for Aura",
+        type: 3,
+        required: true,
+        max_length: 1800,
+      },
+    ],
+  },
+  {
+    name: "github",
+    description: "Inspect or request an approved action on Aura-Core GitHub",
+    type: 1,
+    options: [
+      {
+        name: "task",
+        description: "Use APPROVE WRITE: only for an intentional write",
+        type: 3,
+        required: true,
+        max_length: 1800,
+      },
+    ],
+  },
+  {
+    name: "skygrid",
+    description: "Check the configured SKYGRID status endpoint",
+    type: 1,
+  },
+];
+
+const route = guildId
+  ? `/applications/${applicationId}/guilds/${guildId}/commands`
+  : `/applications/${applicationId}/commands`;
+
+const response = await fetch(`https://discord.com/api/v10${route}`, {
+  method: "PUT",
+  headers: {
+    Authorization: `Bot ${botToken}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify(commands),
+});
+
+const body = await response.text();
+if (!response.ok) {
+  console.error(`Discord API ${response.status}: ${body}`);
+  process.exit(1);
+}
+
+const registered = JSON.parse(body);
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      scope: guildId ? `guild:${guildId}` : "global",
+      commands: registered.map((command) => command.name),
+    },
+    null,
+    2,
+  ),
+);

--- a/apps/aura-work-agent/src/app/api/aura/route.ts
+++ b/apps/aura-work-agent/src/app/api/aura/route.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import { runAuraAgent } from "@/lib/agent";
+import { DEFAULT_AURA_LOCAL_PREFERENCES } from "@/lib/aura-profile";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+const preferencesSchema = z.object({
+  preferredName: z.string().trim().min(1).max(40),
+  tone: z.enum(["warm-precise", "direct-operational", "encouraging-playful"]),
+  responseLength: z.enum(["short", "balanced", "detailed"]),
+  emojiLevel: z.enum(["none", "light", "expressive"]),
+  familyFriendly: z.boolean(),
+});
+
+const requestSchema = z.object({
+  prompt: z.string().trim().min(1).max(8_000),
+  preferences: preferencesSchema.default(DEFAULT_AURA_LOCAL_PREFERENCES),
+  feedbackCount: z.number().int().min(0).max(10_000).default(0),
+});
+
+export async function POST(request: Request): Promise<Response> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ ok: false, error: "Request body must be valid JSON." }, { status: 400 });
+  }
+
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      {
+        ok: false,
+        error: "Invalid local Aura request.",
+        details: parsed.error.flatten().fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const response = await runAuraAgent({
+      prompt: parsed.data.prompt,
+      actorId: "local-browser",
+      actorName: parsed.data.preferences.preferredName,
+      preferences: parsed.data.preferences,
+      feedbackCount: parsed.data.feedbackCount,
+      outputMode: "local",
+    });
+
+    return Response.json({ ok: true, response });
+  } catch (error) {
+    console.error("Local Aura request failed", error);
+    return Response.json(
+      {
+        ok: false,
+        error: "Aura could not complete this local request.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/aura-work-agent/src/app/api/discord/gateway/route.ts
+++ b/apps/aura-work-agent/src/app/api/discord/gateway/route.ts
@@ -1,5 +1,5 @@
 import { after } from "next/server";
-import { getBot } from "@/lib/bot";
+import { getBot, getDiscordAdapter } from "@/lib/bot";
 
 export const runtime = "nodejs";
 export const maxDuration = 800;
@@ -14,14 +14,12 @@ export async function GET(request: Request): Promise<Response> {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const bot = getBot();
-  await bot.initialize();
+  await getBot().initialize();
 
-  const discord = bot.getAdapter("discord");
   const webhookUrl = new URL("/api/webhooks/discord", request.url).toString();
 
-  return discord.startGatewayListener(
-    { waitUntil: (task) => after(() => task) },
+  return getDiscordAdapter().startGatewayListener(
+    { waitUntil: (task: Promise<unknown>) => after(() => task) },
     600_000,
     undefined,
     webhookUrl,

--- a/apps/aura-work-agent/src/app/api/discord/gateway/route.ts
+++ b/apps/aura-work-agent/src/app/api/discord/gateway/route.ts
@@ -1,0 +1,29 @@
+import { after } from "next/server";
+import { getBot } from "@/lib/bot";
+
+export const runtime = "nodejs";
+export const maxDuration = 800;
+
+export async function GET(request: Request): Promise<Response> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return new Response("CRON_SECRET not configured", { status: 500 });
+  }
+
+  if (request.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const bot = getBot();
+  await bot.initialize();
+
+  const discord = bot.getAdapter("discord");
+  const webhookUrl = new URL("/api/webhooks/discord", request.url).toString();
+
+  return discord.startGatewayListener(
+    { waitUntil: (task) => after(() => task) },
+    600_000,
+    undefined,
+    webhookUrl,
+  );
+}

--- a/apps/aura-work-agent/src/app/api/health/route.ts
+++ b/apps/aura-work-agent/src/app/api/health/route.ts
@@ -1,0 +1,27 @@
+export const runtime = "nodejs";
+
+export async function GET(): Promise<Response> {
+  const required = [
+    "OPENAI_API_KEY",
+    "DISCORD_BOT_TOKEN",
+    "DISCORD_PUBLIC_KEY",
+    "DISCORD_APPLICATION_ID",
+    "GITHUB_TOKEN",
+    "DISCORD_OPERATOR_USER_IDS",
+  ];
+
+  const missing = required.filter((name) => !process.env[name]);
+
+  return Response.json(
+    {
+      ok: missing.length === 0,
+      service: "Aura Work Agent",
+      product: "SKYGRID Emergency Data On-Ramp",
+      runtime: "discord-openai-github",
+      state: process.env.REDIS_URL ? "redis" : "memory",
+      missing,
+      timestamp: new Date().toISOString(),
+    },
+    { status: missing.length === 0 ? 200 : 503 },
+  );
+}

--- a/apps/aura-work-agent/src/app/api/webhooks/discord/route.ts
+++ b/apps/aura-work-agent/src/app/api/webhooks/discord/route.ts
@@ -1,0 +1,11 @@
+import { after } from "next/server";
+import { getBot } from "@/lib/bot";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export async function POST(request: Request): Promise<Response> {
+  return getBot().webhooks.discord(request, {
+    waitUntil: (task) => after(() => task),
+  });
+}

--- a/apps/aura-work-agent/src/app/aura-local-client.tsx
+++ b/apps/aura-work-agent/src/app/aura-local-client.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  DEFAULT_AURA_LOCAL_PREFERENCES,
+  type AuraLocalPreferences,
+} from "@/lib/aura-profile";
+
+const PROFILE_KEY = "aura-core:local-preferences:v1";
+const FEEDBACK_KEY = "aura-core:positive-feedback:v1";
+
+function readStoredProfile(): AuraLocalPreferences {
+  try {
+    const value = window.localStorage.getItem(PROFILE_KEY);
+    if (!value) return DEFAULT_AURA_LOCAL_PREFERENCES;
+    return { ...DEFAULT_AURA_LOCAL_PREFERENCES, ...JSON.parse(value) };
+  } catch {
+    return DEFAULT_AURA_LOCAL_PREFERENCES;
+  }
+}
+
+function readFeedbackCount(): number {
+  const value = Number.parseInt(window.localStorage.getItem(FEEDBACK_KEY) ?? "0", 10);
+  return Number.isFinite(value) ? Math.max(0, Math.min(10_000, value)) : 0;
+}
+
+const fieldStyle = {
+  width: "100%",
+  boxSizing: "border-box" as const,
+  borderRadius: 12,
+  border: "1px solid #475569",
+  background: "#0f172a",
+  color: "#f8fafc",
+  padding: "10px 12px",
+};
+
+const labelStyle = {
+  display: "grid",
+  gap: 6,
+  color: "#dbeafe",
+  fontSize: 14,
+};
+
+export function AuraLocalClient() {
+  const [preferences, setPreferences] = useState<AuraLocalPreferences>(
+    DEFAULT_AURA_LOCAL_PREFERENCES,
+  );
+  const [feedbackCount, setFeedbackCount] = useState(0);
+  const [prompt, setPrompt] = useState("");
+  const [response, setResponse] = useState(
+    "Hello MVP. I am ready to learn the presentation style you prefer while keeping security and factual standards fixed.",
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [likedCurrent, setLikedCurrent] = useState(false);
+
+  useEffect(() => {
+    setPreferences(readStoredProfile());
+    setFeedbackCount(readFeedbackCount());
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(PROFILE_KEY, JSON.stringify(preferences));
+  }, [preferences]);
+
+  const feedbackLabel = useMemo(
+    () => `${feedbackCount} family thumbs-up${feedbackCount === 1 ? "" : "s"}`,
+    [feedbackCount],
+  );
+
+  function updatePreference<K extends keyof AuraLocalPreferences>(
+    key: K,
+    value: AuraLocalPreferences[K],
+  ) {
+    setPreferences((current) => ({ ...current, [key]: value }));
+  }
+
+  async function submitPrompt(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!prompt.trim() || isLoading) return;
+
+    setIsLoading(true);
+    setError("");
+    setLikedCurrent(false);
+
+    try {
+      const request = await fetch("/api/aura", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt: prompt.trim(),
+          preferences,
+          feedbackCount,
+        }),
+      });
+      const body = (await request.json()) as {
+        ok?: boolean;
+        response?: string;
+        error?: string;
+      };
+
+      if (!request.ok || !body.ok || !body.response) {
+        throw new Error(body.error ?? `Aura request failed with status ${request.status}.`);
+      }
+
+      setResponse(body.response);
+      setPrompt("");
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Aura request failed.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function addThumbsUp() {
+    if (likedCurrent) return;
+    const nextCount = Math.min(10_000, feedbackCount + 1);
+    setFeedbackCount(nextCount);
+    window.localStorage.setItem(FEEDBACK_KEY, String(nextCount));
+    setLikedCurrent(true);
+  }
+
+  function resetLocalLearning() {
+    setPreferences(DEFAULT_AURA_LOCAL_PREFERENCES);
+    setFeedbackCount(0);
+    setLikedCurrent(false);
+    window.localStorage.removeItem(PROFILE_KEY);
+    window.localStorage.removeItem(FEEDBACK_KEY);
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 24 }}>
+      <section
+        aria-labelledby="aura-preferences-title"
+        style={{
+          display: "grid",
+          gap: 16,
+          padding: 20,
+          borderRadius: 16,
+          border: "1px solid #334155",
+          background: "rgba(15, 23, 42, .72)",
+        }}
+      >
+        <div>
+          <h2 id="aura-preferences-title" style={{ margin: 0 }}>
+            Teach Aura your style
+          </h2>
+          <p style={{ marginBottom: 0, color: "#94a3b8", lineHeight: 1.6 }}>
+            These settings stay in this browser. They affect presentation only—not permissions,
+            security gates, or facts.
+          </p>
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            gap: 14,
+          }}
+        >
+          <label style={labelStyle}>
+            Call me
+            <input
+              value={preferences.preferredName}
+              maxLength={40}
+              onChange={(event) => updatePreference("preferredName", event.target.value)}
+              style={fieldStyle}
+            />
+          </label>
+
+          <label style={labelStyle}>
+            Tone
+            <select
+              value={preferences.tone}
+              onChange={(event) =>
+                updatePreference("tone", event.target.value as AuraLocalPreferences["tone"])
+              }
+              style={fieldStyle}
+            >
+              <option value="warm-precise">Warm and precise</option>
+              <option value="direct-operational">Direct and operational</option>
+              <option value="encouraging-playful">Encouraging and playful</option>
+            </select>
+          </label>
+
+          <label style={labelStyle}>
+            Response length
+            <select
+              value={preferences.responseLength}
+              onChange={(event) =>
+                updatePreference(
+                  "responseLength",
+                  event.target.value as AuraLocalPreferences["responseLength"],
+                )
+              }
+              style={fieldStyle}
+            >
+              <option value="short">Short</option>
+              <option value="balanced">Balanced</option>
+              <option value="detailed">Detailed</option>
+            </select>
+          </label>
+
+          <label style={labelStyle}>
+            Emoji level
+            <select
+              value={preferences.emojiLevel}
+              onChange={(event) =>
+                updatePreference(
+                  "emojiLevel",
+                  event.target.value as AuraLocalPreferences["emojiLevel"],
+                )
+              }
+              style={fieldStyle}
+            >
+              <option value="none">None</option>
+              <option value="light">Light</option>
+              <option value="expressive">Expressive</option>
+            </select>
+          </label>
+        </div>
+
+        <label style={{ display: "flex", gap: 10, alignItems: "center", color: "#dbeafe" }}>
+          <input
+            type="checkbox"
+            checked={preferences.familyFriendly}
+            onChange={(event) => updatePreference("familyFriendly", event.target.checked)}
+          />
+          Keep language family-friendly and easy to share
+        </label>
+      </section>
+
+      <section
+        aria-labelledby="aura-local-title"
+        style={{
+          display: "grid",
+          gap: 16,
+          padding: 20,
+          borderRadius: 16,
+          border: "1px solid #7c3aed",
+          background: "linear-gradient(145deg, rgba(30, 41, 59, .96), rgba(46, 16, 101, .7))",
+        }}
+      >
+        <div>
+          <p style={{ margin: 0, color: "#c4b5fd", letterSpacing: ".08em" }}>
+            LOCAL AURA-CORE SESSION
+          </p>
+          <h2 id="aura-local-title" style={{ margin: "6px 0 0" }}>
+            Talk with Aura
+          </h2>
+        </div>
+
+        <form onSubmit={submitPrompt} style={{ display: "grid", gap: 12 }}>
+          <label style={labelStyle}>
+            Your request
+            <textarea
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              rows={4}
+              maxLength={8_000}
+              placeholder="Ask Aura about Aura-Core, SKYGRID, GitHub work, or how to explain something to the family."
+              style={{ ...fieldStyle, resize: "vertical" }}
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={isLoading || !prompt.trim()}
+            style={{
+              justifySelf: "start",
+              border: 0,
+              borderRadius: 12,
+              padding: "11px 18px",
+              background: isLoading ? "#475569" : "#7c3aed",
+              color: "white",
+              fontWeight: 700,
+              cursor: isLoading ? "wait" : "pointer",
+            }}
+          >
+            {isLoading ? "Aura is thinking…" : "Ask Aura"}
+          </button>
+        </form>
+
+        {error ? (
+          <p role="alert" style={{ color: "#fca5a5", margin: 0 }}>
+            {error}
+          </p>
+        ) : null}
+
+        <article
+          aria-live="polite"
+          style={{
+            whiteSpace: "pre-wrap",
+            lineHeight: 1.7,
+            padding: 18,
+            borderRadius: 14,
+            background: "rgba(2, 6, 23, .68)",
+            border: "1px solid #475569",
+          }}
+        >
+          {response}
+        </article>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 12,
+            alignItems: "center",
+            justifyContent: "space-between",
+            flexWrap: "wrap",
+          }}
+        >
+          <button
+            type="button"
+            onClick={addThumbsUp}
+            disabled={likedCurrent}
+            aria-label="Give Aura a family thumbs-up for this response"
+            style={{
+              border: "1px solid #fbbf24",
+              borderRadius: 999,
+              padding: "12px 18px",
+              background: likedCurrent ? "#365314" : "#422006",
+              color: "#fef3c7",
+              fontWeight: 800,
+              fontSize: 16,
+              cursor: likedCurrent ? "default" : "pointer",
+            }}
+          >
+            {likedCurrent ? "👍 Thank you!" : "👍 Family thumbs-up"}
+          </button>
+          <strong style={{ color: "#fde68a" }}>{feedbackLabel}</strong>
+        </div>
+      </section>
+
+      <section
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 16,
+          flexWrap: "wrap",
+          color: "#94a3b8",
+          fontSize: 14,
+        }}
+      >
+        <p style={{ margin: 0 }}>
+          Aura recognizes explicit settings—not faces, voices, or family identities. Thumbs-up
+          feedback stays on this device.
+        </p>
+        <button
+          type="button"
+          onClick={resetLocalLearning}
+          style={{
+            border: "1px solid #64748b",
+            borderRadius: 10,
+            padding: "8px 12px",
+            background: "transparent",
+            color: "#cbd5e1",
+            cursor: "pointer",
+          }}
+        >
+          Reset local learning
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/apps/aura-work-agent/src/app/layout.tsx
+++ b/apps/aura-work-agent/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "Aura Work Agent",
+  description: "Discord operations agent for SKYGRID and Aura-Core",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, background: "#090b18", color: "#eef2ff" }}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/aura-work-agent/src/app/page.tsx
+++ b/apps/aura-work-agent/src/app/page.tsx
@@ -1,3 +1,5 @@
+import { AuraLocalClient } from "@/app/aura-local-client";
+
 const commands = [
   "/aura prompt:<question>",
   "/github task:<repository task>",
@@ -10,44 +12,63 @@ export default function HomePage() {
     <main
       style={{
         minHeight: "100vh",
-        display: "grid",
-        placeItems: "center",
-        padding: 32,
+        padding: "32px 20px 64px",
         fontFamily: "system-ui, sans-serif",
       }}
     >
-      <section
-        style={{
-          width: "min(760px, 100%)",
-          padding: 32,
-          border: "1px solid #334155",
-          borderRadius: 20,
-          background: "linear-gradient(145deg, #11172a, #17112d)",
-          boxShadow: "0 24px 80px rgba(0,0,0,.35)",
-        }}
-      >
-        <p style={{ letterSpacing: ".14em", textTransform: "uppercase", color: "#93c5fd" }}>
-          SKYGRID Emergency Data On-Ramp
-        </p>
-        <h1 style={{ margin: "8px 0 12px", fontSize: "clamp(2rem, 6vw, 4rem)" }}>
-          Aura Work Agent
-        </h1>
-        <p style={{ color: "#cbd5e1", lineHeight: 1.7 }}>
-          Discord operations agent powered by the OpenAI Agents SDK, with allowlisted GitHub
-          tools and explicit approval gates for writes.
-        </p>
-        <h2 style={{ marginTop: 28 }}>Commands</h2>
-        <ul style={{ lineHeight: 1.9, color: "#dbeafe" }}>
-          {commands.map((command) => (
-            <li key={command}>
-              <code>{command}</code>
-            </li>
-          ))}
-        </ul>
-        <p style={{ marginTop: 28 }}>
-          Readiness: <a href="/api/health" style={{ color: "#60a5fa" }}>/api/health</a>
-        </p>
-      </section>
+      <div style={{ width: "min(980px, 100%)", margin: "0 auto", display: "grid", gap: 24 }}>
+        <header
+          style={{
+            padding: 28,
+            border: "1px solid #334155",
+            borderRadius: 20,
+            background: "linear-gradient(145deg, #11172a, #17112d)",
+            boxShadow: "0 24px 80px rgba(0,0,0,.35)",
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              letterSpacing: ".14em",
+              textTransform: "uppercase",
+              color: "#93c5fd",
+            }}
+          >
+            SKYGRID Emergency Data On-Ramp
+          </p>
+          <h1 style={{ margin: "8px 0 12px", fontSize: "clamp(2rem, 6vw, 4rem)" }}>
+            Aura Work Agent
+          </h1>
+          <p style={{ color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760 }}>
+            Teach your local Aura-Core how you prefer responses to feel, then let family members
+            give a visible thumbs-up when Aura gets the presentation right. Preferences stay in
+            this browser and never override security controls.
+          </p>
+          <p style={{ marginBottom: 0 }}>
+            Readiness: <a href="/api/health" style={{ color: "#60a5fa" }}>/api/health</a>
+          </p>
+        </header>
+
+        <AuraLocalClient />
+
+        <section
+          style={{
+            padding: 20,
+            border: "1px solid #334155",
+            borderRadius: 16,
+            background: "rgba(15, 23, 42, .62)",
+          }}
+        >
+          <h2 style={{ marginTop: 0 }}>Discord commands</h2>
+          <ul style={{ lineHeight: 1.9, color: "#dbeafe", marginBottom: 0 }}>
+            {commands.map((command) => (
+              <li key={command}>
+                <code>{command}</code>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
     </main>
   );
 }

--- a/apps/aura-work-agent/src/app/page.tsx
+++ b/apps/aura-work-agent/src/app/page.tsx
@@ -1,0 +1,53 @@
+const commands = [
+  "/aura prompt:<question>",
+  "/github task:<repository task>",
+  "/skygrid",
+  "APPROVE WRITE: create an issue …",
+];
+
+export default function HomePage() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: 32,
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      <section
+        style={{
+          width: "min(760px, 100%)",
+          padding: 32,
+          border: "1px solid #334155",
+          borderRadius: 20,
+          background: "linear-gradient(145deg, #11172a, #17112d)",
+          boxShadow: "0 24px 80px rgba(0,0,0,.35)",
+        }}
+      >
+        <p style={{ letterSpacing: ".14em", textTransform: "uppercase", color: "#93c5fd" }}>
+          SKYGRID Emergency Data On-Ramp
+        </p>
+        <h1 style={{ margin: "8px 0 12px", fontSize: "clamp(2rem, 6vw, 4rem)" }}>
+          Aura Work Agent
+        </h1>
+        <p style={{ color: "#cbd5e1", lineHeight: 1.7 }}>
+          Discord operations agent powered by the OpenAI Agents SDK, with allowlisted GitHub
+          tools and explicit approval gates for writes.
+        </p>
+        <h2 style={{ marginTop: 28 }}>Commands</h2>
+        <ul style={{ lineHeight: 1.9, color: "#dbeafe" }}>
+          {commands.map((command) => (
+            <li key={command}>
+              <code>{command}</code>
+            </li>
+          ))}
+        </ul>
+        <p style={{ marginTop: 28 }}>
+          Readiness: <a href="/api/health" style={{ color: "#60a5fa" }}>/api/health</a>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/aura-work-agent/src/lib/agent.ts
+++ b/apps/aura-work-agent/src/lib/agent.ts
@@ -1,5 +1,11 @@
 import { Agent, run } from "@openai/agents";
 import {
+  AURA_CORE_IDENTITY,
+  DEFAULT_AURA_LOCAL_PREFERENCES,
+  buildAuraPreferenceContext,
+  type AuraLocalPreferences,
+} from "@/lib/aura-profile";
+import {
   githubCommentOnIssue,
   githubCreateIssue,
   githubListOpenIssues,
@@ -13,8 +19,7 @@ const auraAgent = new Agent<AuraAgentContext>({
   name: "Aura Work Agent",
   model: process.env.OPENAI_MODEL ?? "gpt-5.4-mini",
   instructions: `
-You are Aura Work Agent for SKYGRID Emergency Data On-Ramp and Aura-Core.
-Be precise, concise, and operationally useful.
+${AURA_CORE_IDENTITY}
 
 GitHub policy:
 - You may read only repositories exposed by the provided GitHub tools.
@@ -56,9 +61,14 @@ export async function runAuraAgent(input: {
   prompt: string;
   actorId: string;
   actorName: string;
+  preferences?: AuraLocalPreferences;
+  feedbackCount?: number;
+  outputMode?: "discord" | "local";
 }): Promise<string> {
   const explicitWriteApproval = WRITE_APPROVAL_PREFIX.test(input.prompt);
   const operatorAuthorized = operatorUserIds().has(input.actorId);
+  const preferences = input.preferences ?? DEFAULT_AURA_LOCAL_PREFERENCES;
+  const feedbackCount = input.feedbackCount ?? 0;
 
   const context: AuraAgentContext = {
     actorId: input.actorId,
@@ -68,9 +78,13 @@ export async function runAuraAgent(input: {
   };
 
   const prompt = [
-    `Discord actor: ${input.actorName} (${input.actorId})`,
+    `Actor: ${input.actorName} (${input.actorId})`,
+    `Interface: ${input.outputMode ?? "discord"}`,
     `Operator authorized: ${operatorAuthorized ? "yes" : "no"}`,
     `Explicit write approval prefix: ${explicitWriteApproval ? "present" : "absent"}`,
+    "",
+    "Current explicit presentation preferences:",
+    buildAuraPreferenceContext(preferences, feedbackCount),
     "",
     input.prompt,
   ].join("\n");
@@ -87,7 +101,7 @@ export async function runAuraAgent(input: {
       } else {
         result.state.reject(interruption, {
           message:
-            "Write action rejected. The Discord user must be allowlisted and the request must begin with APPROVE WRITE:.",
+            "Write action rejected. The authenticated Discord user must be allowlisted and the request must begin with APPROVE WRITE:.",
         });
       }
     }
@@ -99,5 +113,6 @@ export async function runAuraAgent(input: {
     return "The agent stopped because a write action still requires approval.";
   }
 
-  return compactDiscordOutput(result.finalOutput);
+  const output = String(result.finalOutput ?? "No response generated.").trim();
+  return input.outputMode === "local" ? output : compactDiscordOutput(output);
 }

--- a/apps/aura-work-agent/src/lib/agent.ts
+++ b/apps/aura-work-agent/src/lib/agent.ts
@@ -1,0 +1,103 @@
+import { Agent, run } from "@openai/agents";
+import {
+  githubCommentOnIssue,
+  githubCreateIssue,
+  githubListOpenIssues,
+  githubRepositoryOverview,
+  type AuraAgentContext,
+} from "@/lib/github-tools";
+
+const WRITE_APPROVAL_PREFIX = /^\s*APPROVE WRITE:\s*/i;
+
+const auraAgent = new Agent<AuraAgentContext>({
+  name: "Aura Work Agent",
+  model: process.env.OPENAI_MODEL ?? "gpt-5.4-mini",
+  instructions: `
+You are Aura Work Agent for SKYGRID Emergency Data On-Ramp and Aura-Core.
+Be precise, concise, and operationally useful.
+
+GitHub policy:
+- You may read only repositories exposed by the provided GitHub tools.
+- Before recommending work, inspect repository metadata or current issues when relevant.
+- Never claim a GitHub write occurred unless a write tool returned success.
+- GitHub writes require both an allowlisted operator and a request beginning exactly with "APPROVE WRITE:".
+- When write approval is absent, explain the proposed write without attempting to bypass the gate.
+- Do not request or reveal tokens, API keys, secrets, private keys, or credentials.
+- Do not merge pull requests, modify workflow permissions, alter repository settings, or delete content.
+
+Keep Discord responses under 1,800 characters unless the user explicitly requests a longer artifact.
+  `.trim(),
+  tools: [
+    githubRepositoryOverview,
+    githubListOpenIssues,
+    githubCreateIssue,
+    githubCommentOnIssue,
+  ],
+});
+
+function operatorUserIds(): Set<string> {
+  return new Set(
+    (process.env.DISCORD_OPERATOR_USER_IDS ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+function compactDiscordOutput(value: unknown): string {
+  const text = String(value ?? "No response generated.").trim();
+  if (text.length <= 1_800) {
+    return text;
+  }
+  return `${text.slice(0, 1_760)}\n\n…response truncated`;
+}
+
+export async function runAuraAgent(input: {
+  prompt: string;
+  actorId: string;
+  actorName: string;
+}): Promise<string> {
+  const explicitWriteApproval = WRITE_APPROVAL_PREFIX.test(input.prompt);
+  const operatorAuthorized = operatorUserIds().has(input.actorId);
+
+  const context: AuraAgentContext = {
+    actorId: input.actorId,
+    actorName: input.actorName,
+    explicitWriteApproval,
+    operatorAuthorized,
+  };
+
+  const prompt = [
+    `Discord actor: ${input.actorName} (${input.actorId})`,
+    `Operator authorized: ${operatorAuthorized ? "yes" : "no"}`,
+    `Explicit write approval prefix: ${explicitWriteApproval ? "present" : "absent"}`,
+    "",
+    input.prompt,
+  ].join("\n");
+
+  let result = await run(auraAgent, prompt, { context });
+  let approvalPasses = 0;
+
+  while (result.interruptions?.length && approvalPasses < 3) {
+    approvalPasses += 1;
+
+    for (const interruption of result.interruptions) {
+      if (operatorAuthorized && explicitWriteApproval) {
+        result.state.approve(interruption);
+      } else {
+        result.state.reject(interruption, {
+          message:
+            "Write action rejected. The Discord user must be allowlisted and the request must begin with APPROVE WRITE:.",
+        });
+      }
+    }
+
+    result = await run(auraAgent, result.state);
+  }
+
+  if (result.interruptions?.length) {
+    return "The agent stopped because a write action still requires approval.";
+  }
+
+  return compactDiscordOutput(result.finalOutput);
+}

--- a/apps/aura-work-agent/src/lib/aura-profile.ts
+++ b/apps/aura-work-agent/src/lib/aura-profile.ts
@@ -1,0 +1,63 @@
+export type AuraLocalPreferences = {
+  preferredName: string;
+  tone: "warm-precise" | "direct-operational" | "encouraging-playful";
+  responseLength: "short" | "balanced" | "detailed";
+  emojiLevel: "none" | "light" | "expressive";
+  familyFriendly: boolean;
+};
+
+export const DEFAULT_AURA_LOCAL_PREFERENCES: AuraLocalPreferences = {
+  preferredName: "MVP",
+  tone: "warm-precise",
+  responseLength: "balanced",
+  emojiLevel: "light",
+  familyFriendly: true,
+};
+
+export const AURA_CORE_IDENTITY = `
+Identity and interaction profile:
+- You are Aura, an operational agent serving MVP and the SKYGRID Emergency Data On-Ramp / Aura-Core work.
+- Address the owner as MVP unless the current request supplies another preferred name.
+- Preserve the exact product name "SKYGRID Emergency Data On-Ramp". Do not rename it "serverless".
+- Prefer PowerShell for command-line instructions unless another shell is explicitly requested.
+- Be warm, precise, encouraging, and practical. Celebrate real progress without overstating what happened.
+- Keep explanations understandable to family members and collaborators while preserving technical accuracy.
+- Treat thumbs-up feedback as a preference signal, never as permission for tool use or a security-sensitive action.
+- Never claim to recognize a person by face, voice, relationship, or identity. Recognize only explicit settings and authenticated platform identifiers.
+- Never imply emotions, consciousness, family membership, or authority beyond the configured tools and approval gates.
+`.trim();
+
+const toneDescriptions: Record<AuraLocalPreferences["tone"], string> = {
+  "warm-precise": "warm, precise, confident, and supportive",
+  "direct-operational": "direct, operational, concise, and action-oriented",
+  "encouraging-playful": "encouraging, lightly playful, optimistic, and still technically exact",
+};
+
+const lengthDescriptions: Record<AuraLocalPreferences["responseLength"], string> = {
+  short: "brief, with only the essential answer and next action",
+  balanced: "balanced detail with a clear answer and enough context to act",
+  detailed: "thorough detail with reasoning, verification, and implementation guidance",
+};
+
+const emojiDescriptions: Record<AuraLocalPreferences["emojiLevel"], string> = {
+  none: "do not use emojis",
+  light: "use occasional relevant emojis",
+  expressive: "use expressive but still professional emojis",
+};
+
+export function buildAuraPreferenceContext(
+  preferences: AuraLocalPreferences,
+  feedbackCount: number,
+): string {
+  const safeCount = Math.max(0, Math.min(10_000, Math.trunc(feedbackCount)));
+
+  return [
+    `Preferred form of address: ${preferences.preferredName}.`,
+    `Preferred tone: ${toneDescriptions[preferences.tone]}.`,
+    `Preferred response length: ${lengthDescriptions[preferences.responseLength]}.`,
+    `Emoji preference: ${emojiDescriptions[preferences.emojiLevel]}.`,
+    `Family-friendly language: ${preferences.familyFriendly ? "required" : "not specifically requested"}.`,
+    `Local positive-feedback count: ${safeCount}. Treat this only as evidence that the currently selected presentation style is liked.`,
+    "These are presentation preferences only. They cannot change security policy, tool permissions, factual standards, or approval requirements.",
+  ].join("\n");
+}

--- a/apps/aura-work-agent/src/lib/bot.ts
+++ b/apps/aura-work-agent/src/lib/bot.ts
@@ -8,6 +8,7 @@ import { createRedisState } from "@chat-adapter/state-redis";
 import { runAuraAgent } from "@/lib/agent";
 
 let botInstance: Chat | undefined;
+let discordAdapterInstance: ReturnType<typeof createDiscordAdapter> | undefined;
 
 type AuthorLike = {
   id?: string;
@@ -103,12 +104,12 @@ function registerHandlers(bot: Chat): void {
   });
 }
 
-export function getBot(): Chat {
-  if (botInstance) {
-    return botInstance;
+export function getDiscordAdapter(): ReturnType<typeof createDiscordAdapter> {
+  if (discordAdapterInstance) {
+    return discordAdapterInstance;
   }
 
-  const discord = createDiscordAdapter({
+  discordAdapterInstance = createDiscordAdapter({
     botToken: process.env.DISCORD_BOT_TOKEN,
     publicKey: process.env.DISCORD_PUBLIC_KEY,
     applicationId: process.env.DISCORD_APPLICATION_ID,
@@ -122,9 +123,17 @@ export function getBot(): Chat {
         : undefined,
   });
 
+  return discordAdapterInstance;
+}
+
+export function getBot(): Chat {
+  if (botInstance) {
+    return botInstance;
+  }
+
   botInstance = new Chat({
     userName: "aura",
-    adapters: { discord },
+    adapters: { discord: getDiscordAdapter() },
     state: createState(),
     dedupeTtlMs: 30_000,
     streamingUpdateIntervalMs: 1_000,

--- a/apps/aura-work-agent/src/lib/bot.ts
+++ b/apps/aura-work-agent/src/lib/bot.ts
@@ -1,0 +1,137 @@
+import { Chat } from "chat";
+import {
+  createDiscordAdapter,
+  DiscordInteractionResponseFlag,
+} from "@chat-adapter/discord";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { createRedisState } from "@chat-adapter/state-redis";
+import { runAuraAgent } from "@/lib/agent";
+
+let botInstance: Chat | undefined;
+
+type AuthorLike = {
+  id?: string;
+  userId?: string;
+  fullName?: string;
+  userName?: string;
+};
+
+function actor(author: AuthorLike | undefined): { id: string; name: string } {
+  return {
+    id: String(author?.id ?? author?.userId ?? "unknown"),
+    name: String(author?.fullName ?? author?.userName ?? "Discord user"),
+  };
+}
+
+function createState() {
+  const redisUrl = process.env.REDIS_URL;
+  if (redisUrl) {
+    return createRedisState({
+      url: redisUrl,
+      keyPrefix: "skygrid:aura-work-agent",
+    });
+  }
+  return createMemoryState();
+}
+
+async function skygridStatus(): Promise<string> {
+  const statusUrl = process.env.SKYGRID_STATUS_URL;
+  if (!statusUrl) {
+    return "SKYGRID_STATUS_URL is not configured.";
+  }
+
+  try {
+    const response = await fetch(statusUrl, {
+      headers: { "User-Agent": "skygrid-aura-work-agent" },
+      signal: AbortSignal.timeout(10_000),
+      cache: "no-store",
+    });
+    const body = await response.text();
+    return [
+      `SKYGRID status: ${response.status} ${response.statusText}`,
+      `Endpoint: ${statusUrl}`,
+      body ? `Response: ${body.slice(0, 1_200)}` : "Response body: empty",
+    ].join("\n");
+  } catch (error) {
+    return `SKYGRID status check failed: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+function registerHandlers(bot: Chat): void {
+  bot.onDirectMessage(async (thread, message) => {
+    const sender = actor(message.author as AuthorLike);
+    const response = await runAuraAgent({
+      prompt: message.text,
+      actorId: sender.id,
+      actorName: sender.name,
+    });
+    await thread.post(response);
+  });
+
+  bot.onNewMention(async (thread, message) => {
+    const sender = actor(message.author as AuthorLike);
+    const response = await runAuraAgent({
+      prompt: message.text,
+      actorId: sender.id,
+      actorName: sender.name,
+    });
+    await thread.post(response);
+  });
+
+  bot.onSlashCommand("/aura", async (event) => {
+    const sender = actor(event.user as AuthorLike);
+    const response = await runAuraAgent({
+      prompt: event.text || "Explain what you can do.",
+      actorId: sender.id,
+      actorName: sender.name,
+    });
+    await event.channel.post(response);
+  });
+
+  bot.onSlashCommand("/github", async (event) => {
+    const sender = actor(event.user as AuthorLike);
+    const response = await runAuraAgent({
+      prompt: event.text || "Summarize the allowlisted GitHub repository.",
+      actorId: sender.id,
+      actorName: sender.name,
+    });
+    await event.channel.post(response);
+  });
+
+  bot.onSlashCommand("/skygrid", async (event) => {
+    await event.channel.post(await skygridStatus());
+  });
+}
+
+export function getBot(): Chat {
+  if (botInstance) {
+    return botInstance;
+  }
+
+  const discord = createDiscordAdapter({
+    botToken: process.env.DISCORD_BOT_TOKEN,
+    publicKey: process.env.DISCORD_PUBLIC_KEY,
+    applicationId: process.env.DISCORD_APPLICATION_ID,
+    mentionRoleIds: (process.env.DISCORD_MENTION_ROLE_IDS ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+    interactionFlags: ({ command }) =>
+      command === "/github"
+        ? DiscordInteractionResponseFlag.Ephemeral
+        : undefined,
+  });
+
+  botInstance = new Chat({
+    userName: "aura",
+    adapters: { discord },
+    state: createState(),
+    dedupeTtlMs: 30_000,
+    streamingUpdateIntervalMs: 1_000,
+    fallbackStreamingPlaceholderText: "Aura is evaluating…",
+    logger: process.env.NODE_ENV === "production" ? "info" : "debug",
+  });
+
+  registerHandlers(botInstance);
+  return botInstance;
+}

--- a/apps/aura-work-agent/src/lib/github-tools.ts
+++ b/apps/aura-work-agent/src/lib/github-tools.ts
@@ -1,0 +1,197 @@
+import { tool, type RunContext } from "@openai/agents";
+import { z } from "zod";
+
+export interface AuraAgentContext {
+  actorId: string;
+  actorName: string;
+  explicitWriteApproval: boolean;
+  operatorAuthorized: boolean;
+}
+
+const repositorySchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, "Use owner/repository format");
+
+function allowedRepositories(): Set<string> {
+  const configured = process.env.GITHUB_ALLOWED_REPOS ?? "MVPuknowme/Aura-core";
+  return new Set(
+    configured
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function requireAllowedRepository(repository: string): string {
+  const normalized = repository.trim();
+  if (!allowedRepositories().has(normalized.toLowerCase())) {
+    throw new Error(`Repository is not allowlisted: ${normalized}`);
+  }
+  return normalized;
+}
+
+async function githubRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("GITHUB_TOKEN is not configured");
+  }
+
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "skygrid-aura-work-agent",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...init.headers,
+    },
+  });
+
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status}: ${body.slice(0, 600)}`);
+  }
+
+  return (body ? JSON.parse(body) : {}) as T;
+}
+
+export const githubRepositoryOverview = tool({
+  name: "github_repository_overview",
+  description:
+    "Read repository metadata for an allowlisted GitHub repository. Use this before making recommendations about repository work.",
+  parameters: z.object({ repository: repositorySchema }),
+  execute: async (
+    { repository },
+    _runContext?: RunContext<AuraAgentContext>,
+  ): Promise<string> => {
+    const allowed = requireAllowedRepository(repository);
+    const data = await githubRequest<{
+      full_name: string;
+      description: string | null;
+      default_branch: string;
+      open_issues_count: number;
+      visibility: string;
+      archived: boolean;
+      html_url: string;
+    }>(`/repos/${allowed}`);
+
+    return JSON.stringify({
+      repository: data.full_name,
+      description: data.description,
+      defaultBranch: data.default_branch,
+      openIssueCount: data.open_issues_count,
+      visibility: data.visibility,
+      archived: data.archived,
+      url: data.html_url,
+    });
+  },
+});
+
+export const githubListOpenIssues = tool({
+  name: "github_list_open_issues",
+  description:
+    "List the newest open issues in an allowlisted GitHub repository. Pull requests are excluded.",
+  parameters: z.object({
+    repository: repositorySchema,
+    limit: z.number().int().min(1).max(20).default(10),
+  }),
+  execute: async (
+    { repository, limit },
+    _runContext?: RunContext<AuraAgentContext>,
+  ): Promise<string> => {
+    const allowed = requireAllowedRepository(repository);
+    const items = await githubRequest<
+      Array<{
+        number: number;
+        title: string;
+        state: string;
+        html_url: string;
+        pull_request?: unknown;
+        labels: Array<{ name?: string }>;
+      }>
+    >(`/repos/${allowed}/issues?state=open&sort=updated&direction=desc&per_page=30`);
+
+    return JSON.stringify(
+      items
+        .filter((item) => !item.pull_request)
+        .slice(0, limit)
+        .map((item) => ({
+          number: item.number,
+          title: item.title,
+          state: item.state,
+          labels: item.labels.map((label) => label.name).filter(Boolean),
+          url: item.html_url,
+        })),
+    );
+  },
+});
+
+export const githubCreateIssue = tool({
+  name: "github_create_issue",
+  description:
+    "Create a GitHub issue in an allowlisted repository. This is a write action and always requires explicit operator approval.",
+  parameters: z.object({
+    repository: repositorySchema,
+    title: z.string().min(3).max(160),
+    body: z.string().min(1).max(20_000),
+    labels: z.array(z.string().min(1).max(50)).max(10).default([]),
+  }),
+  needsApproval: true,
+  execute: async (
+    { repository, title, body, labels },
+    runContext?: RunContext<AuraAgentContext>,
+  ): Promise<string> => {
+    if (!runContext?.context.operatorAuthorized || !runContext.context.explicitWriteApproval) {
+      throw new Error("Operator authorization and explicit write approval are required");
+    }
+
+    const allowed = requireAllowedRepository(repository);
+    const issue = await githubRequest<{
+      number: number;
+      title: string;
+      html_url: string;
+    }>(`/repos/${allowed}/issues`, {
+      method: "POST",
+      body: JSON.stringify({ title, body, labels }),
+    });
+
+    return JSON.stringify({
+      created: true,
+      number: issue.number,
+      title: issue.title,
+      url: issue.html_url,
+    });
+  },
+});
+
+export const githubCommentOnIssue = tool({
+  name: "github_comment_on_issue",
+  description:
+    "Add a comment to an issue or pull request in an allowlisted repository. This is a write action and always requires explicit operator approval.",
+  parameters: z.object({
+    repository: repositorySchema,
+    issueNumber: z.number().int().positive(),
+    body: z.string().min(1).max(20_000),
+  }),
+  needsApproval: true,
+  execute: async (
+    { repository, issueNumber, body },
+    runContext?: RunContext<AuraAgentContext>,
+  ): Promise<string> => {
+    if (!runContext?.context.operatorAuthorized || !runContext.context.explicitWriteApproval) {
+      throw new Error("Operator authorization and explicit write approval are required");
+    }
+
+    const allowed = requireAllowedRepository(repository);
+    const comment = await githubRequest<{ html_url: string }>(
+      `/repos/${allowed}/issues/${issueNumber}/comments`,
+      {
+        method: "POST",
+        body: JSON.stringify({ body }),
+      },
+    );
+
+    return JSON.stringify({ created: true, url: comment.html_url });
+  },
+});

--- a/apps/aura-work-agent/tsconfig.json
+++ b/apps/aura-work-agent/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/aura-work-agent/vercel.json
+++ b/apps/aura-work-agent/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/discord/gateway",
+      "schedule": "*/9 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a standalone `apps/aura-work-agent` deployment that connects Discord to the OpenAI Agents SDK and narrowly scoped GitHub tools for SKYGRID Emergency Data On-Ramp / Aura-Core operations.

## Included

- Discord HTTP Interactions webhook and optional Gateway cron
- `/aura`, `/github`, and `/skygrid` commands
- Direct-message and mention handlers
- OpenAI Agents SDK runtime using the existing server-side `OPENAI_API_KEY`
- Allowlisted GitHub repository reads
- GitHub issue creation and issue/PR comments behind SDK approval interruptions
- Dual write gate: allowlisted Discord user ID plus exact `APPROVE WRITE:` prefix
- Redis production state with memory-only local fallback
- Fail-closed `/api/health` endpoint
- PowerShell-first deployment and registration instructions
- Dedicated Node 24 / pnpm 10.23 validation workflow

## Security boundaries

- No secrets are committed.
- No PR merges, repository settings changes, workflow permission changes, deletions, or repository file writes.
- GitHub access is deny-by-default outside `GITHUB_ALLOWED_REPOS`.
- The health route reports missing variable names only.
- Discord bot installation uses an application install link, not a normal human invite.

## Validation

✅ `pnpm install --no-frozen-lockfile`

✅ `pnpm typecheck`

✅ `pnpm build`

The production build required the documented optional Discord Gateway compression package, which is declared as an optional dependency. The app remains a draft until Discord application credentials, operator user IDs, GitHub credentials, and the deployment URL are configured.