### PR TITLE
Document SKYGRID Local Relevance design-partner pilot

### DIFF
--- a/docs/commercial/SKYGRID-LOCAL-RELEVANCE-OUTREACH.md
+++ b/docs/commercial/SKYGRID-LOCAL-RELEVANCE-OUTREACH.md
@@ -1,0 +1,183 @@
+# SKYGRID Local Relevance Enterprise Outreach Kit
+
+**Use:** Initial partner conversations for the proposed SKYGRID Local Relevance Layer  
+**Founder/operator:** Michael Vincent Patrick  
+**Business email:** mvpuknowme@skygrid-protocol.net
+
+## One-line pitch
+
+SKYGRID provides a privacy-safe locality verification layer that helps advertising and AI platforms avoid geographically unusable promotions before presentation, without relying on MAC addresses or persistent device identity.
+
+## Thirty-second pitch
+
+People regularly receive ads for businesses and services far outside their usable area. SKYGRID proposes a pre-presentation relevance gate that compares a short-lived, coarse locality context with the advertiser's actual service area and returns only an eligibility decision plus an audit receipt. The platform keeps control of ranking, auctions, billing, and creative selection. The goal is to reduce geographically impossible impressions, improve neighborhood-business discovery, and test whether less wasted delivery also reduces infrastructure work.
+
+## Initial enterprise email
+
+**Suggested subject:** Pilot proposal: privacy-safe local relevance verification for ads and AI promotion
+
+Hello [Partner Team],
+
+I am Michael Vincent Patrick, founder/operator of the SKYGRID Emergency Data On-Ramp and Aura-Core.
+
+I am reaching out with a controlled-pilot concept for improving local advertising and sponsored recommendations. People still receive promotions for businesses, events, and services far outside the area where they can act on them. That wastes advertiser spend, platform delivery work, and user attention while making it harder for neighborhood businesses to reach nearby customers.
+
+We are proposing the SKYGRID Local Relevance Layer: a pre-presentation verification service that compares a coarse, short-lived locality token with an advertiser's approved service area and returns a minimal eligible, ineligible, or indeterminate decision with an auditable receipt.
+
+The design deliberately excludes MAC addresses, persistent hardware identifiers, raw location histories, and cross-app identity resolution. Your platform would retain control of its auction, ranking, creative, billing, consent, and policy systems.
+
+I would like to discuss a ninety-day controlled pilot beginning with shadow evaluation, followed by a limited live test only after privacy, security, and policy review. Proposed measurements include geographically impossible impression rate, out-of-service-area clicks, local conversion lift, user feedback, decision latency, and infrastructure work avoided.
+
+Would your advertising, local commerce, recommendations, or privacy engineering team be open to a technical and commercial discovery session?
+
+Sincerely,
+
+Michael Vincent Patrick  
+Founder/operator, SKYGRID Emergency Data On-Ramp / Aura-Core  
+mvpuknowme@skygrid-protocol.net
+
+## Google / YouTube customization
+
+Add after the second paragraph:
+
+> Google Ads already provides location, proximity, location-group, and presence-based campaign controls. SKYGRID is not intended to replace those systems. The proposed pilot would evaluate whether an independent locality-verification receipt can identify campaign or delivery mismatches, especially for businesses whose services are strictly local.
+
+Discovery questions:
+
+- Where do local campaigns most often produce out-of-area complaints or non-converting clicks?
+- Can a shadow evaluator receive coarse campaign-location and matched-location categories without personal data?
+- Which YouTube or Demand Gen campaign types are suitable for a limited local-service pilot?
+- What latency ceiling would be acceptable for preflight versus live serving?
+- Can the pilot use aggregated matched-location reporting for validation?
+
+## Meta customization
+
+Add after the second paragraph:
+
+> Meta already supports location-based audiences, automated delivery, and conversion tooling. SKYGRID would be tested as a locality-quality and service-area verification layer, not as a source of personal profiles or a replacement for Meta's delivery system.
+
+Discovery questions:
+
+- Which local-business campaign categories generate the most geographic mismatch?
+- Can the first test operate at campaign preflight rather than live impression serving?
+- How should the pilot interact with existing location, placement, and conversion controls?
+- What minimum audience and aggregation rules are required to prevent individual inference?
+- Which Meta business or Audience Network partner pathway is appropriate for review?
+
+## OpenAI and AI-native platform customization
+
+Add after the second paragraph:
+
+> AI-native promotion can use richer conversational context, but local usefulness still requires a dependable boundary between what is nearby, what serves the area, and what is merely related to the conversation. SKYGRID would return a coarse local-eligibility decision while leaving sponsored-content selection, labeling, ranking, and user experience under the platform's control.
+
+Discovery questions:
+
+- Which sponsored or merchant-discovery experiences require local service-area verification?
+- Can locality be represented as a temporary non-unique region bucket?
+- How will sponsored results remain clearly separated from organic answers?
+- Which sensitive categories must be excluded from local-context use?
+- Can aggregate pilot reporting measure usefulness without retaining conversation text?
+
+## Agency and regional-platform version
+
+**Suggested subject:** Design-partner pilot for better neighborhood ad relevance
+
+Hello [Name],
+
+I am inviting a small number of agencies and regional commerce platforms to help validate a privacy-safe local advertising concept.
+
+The SKYGRID Local Relevance Layer checks whether a campaign or offer can actually serve a user's coarse local area before the promotion is presented. It does not use MAC addresses or build a personal identity graph. It returns a short-lived eligibility decision and audit receipt.
+
+A design-partner pilot would begin by reviewing existing campaigns in shadow mode and measuring out-of-service-area impressions, clicks, and spend. Only after the baseline is understood would we consider a limited live experiment.
+
+The ideal first partner manages several neighborhood businesses with clear delivery or service boundaries and is willing to compare existing location targeting against an independent verification layer.
+
+Would you be available for a thirty-minute discovery call?
+
+Sincerely,
+
+Michael Vincent Patrick  
+Founder/operator, SKYGRID Emergency Data On-Ramp / Aura-Core  
+mvpuknowme@skygrid-protocol.net
+
+## Discovery-call agenda
+
+1. Confirm the partner's local-advertising failure modes.
+2. Identify a non-sensitive pilot category and geography.
+3. Agree on the minimum data needed for shadow evaluation.
+4. Define privacy, retention, and deletion boundaries.
+5. Establish baseline and success metrics.
+6. Agree on commercial scope, owners, and decision dates.
+7. Document rollback and termination rights.
+
+## Objection handling
+
+### “We already have geo-targeting.”
+
+That is expected. SKYGRID is not proposing replacement geo-targeting. The pilot tests whether an independent, auditable service-area verification step catches mismatches and produces useful evidence without adding persistent identity.
+
+### “This could create more privacy risk.”
+
+The design starts from data minimization: no MAC addresses, no device fingerprints, no raw movement history, short-lived coarse locality, aggregate reporting, and fail-closed policy enforcement. The pilot does not proceed without the partner's privacy and security approval.
+
+### “This will add latency.”
+
+The first phase is campaign preflight or asynchronous shadow evaluation. A live serving path is considered only after latency is measured and a strict budget, timeout, bypass policy, and rollback threshold are agreed.
+
+### “We cannot share user data.”
+
+The pilot should not require personal user data. The preferred inputs are coarse region buckets, advertiser service areas, campaign settings, and aggregated outcomes.
+
+### “The savings are unproven.”
+
+Correct. The proposal is a controlled measurement engagement. SKYGRID will not market savings, conversion lift, or infrastructure reduction as proven before the partner pilot produces evidence.
+
+## Pilot commercial structure
+
+Recommended starting structure:
+
+- discovery workshop;
+- privacy and architecture assessment;
+- fixed-fee shadow pilot;
+- written measurement plan;
+- limited live experiment only after approval;
+- usage-based or licensed deployment only after validated results.
+
+The first proposal should avoid exclusivity and should preserve SKYGRID intellectual property, while giving the partner rights to its own campaign data and agreed pilot results.
+
+## Qualification criteria
+
+Prioritize a prospect when it has:
+
+- clear local service or delivery boundaries;
+- enough campaign volume for aggregate measurement;
+- privacy and engineering participation;
+- an identifiable owner for advertising quality or local commerce;
+- willingness to run a holdout or shadow comparison;
+- authority to fund a controlled pilot.
+
+Do not prioritize prospects seeking individual location histories, MAC-address targeting, covert tracking, sensitive-trait inference, or unreviewed child-directed advertising.
+
+## Outreach sequence
+
+Day 1: concise introduction and pilot proposition.  
+Day 5: follow-up with the one-page pilot brief.  
+Day 12: send a specific measurement hypothesis for the prospect's local-business category.  
+Day 21: close the loop and request referral to advertising quality, local commerce, privacy engineering, or recommendations infrastructure.
+
+## Evidence package to prepare before a partner call
+
+- architecture diagram;
+- data-flow and trust-boundary diagram;
+- privacy threat model;
+- example API request and response;
+- synthetic shadow-pilot report;
+- latency and failure-mode test results;
+- retention and deletion policy;
+- separation controls between commercial and emergency traffic;
+- founder and intellectual-property statement;
+- proposed pilot statement of work.
+
+## Representation boundary
+
+Do not state or imply that SKYGRID is currently integrated with Google, YouTube, Meta, OpenAI, or another promotion engine. Use “proposed pilot,” “experimental module,” and “seeking design partners” until a written relationship exists.

--- a/docs/commercial/SKYGRID-LOCAL-RELEVANCE-PILOT.md
+++ b/docs/commercial/SKYGRID-LOCAL-RELEVANCE-PILOT.md
@@ -1,0 +1,213 @@
+# SKYGRID Local Relevance Pilot
+
+**Status:** Proposed optional commercial module — not production validated  
+**Owner:** Michael Vincent Patrick  
+**Core system:** SKYGRID Emergency Data On-Ramp  
+**Module name:** SKYGRID Local Relevance Layer
+
+## Executive proposition
+
+The SKYGRID Local Relevance Layer is a privacy-preserving decision service intended to help advertising, promotion, recommendation, and AI platforms avoid geographically irrelevant content before an impression is presented.
+
+The module does not identify a person and does not use MAC addresses, advertising IDs, raw GPS trails, or persistent device fingerprints. It evaluates whether an offer is plausibly useful within a short-lived geographic context and returns a minimal eligibility decision with an auditable receipt.
+
+The commercial hypothesis is simple:
+
+> Reduce obviously misplaced impressions, lower wasted delivery and processing, improve neighborhood-business discovery, and preserve user trust without creating another identity graph.
+
+## Problem
+
+Large promotion engines already use location and contextual signals, but users still encounter ads for distant businesses, services outside their delivery area, or offers that are impossible to use locally.
+
+That creates four forms of waste:
+
+1. Advertisers pay for impressions or clicks that cannot convert.
+2. Platforms consume auction, inference, delivery, logging, and measurement resources on low-value placements.
+3. Users receive less useful experiences and may disengage from advertising.
+4. Local businesses compete against geographically irrelevant inventory instead of reaching nearby customers.
+
+## Proposed solution
+
+SKYGRID acts as a pre-presentation relevance gate between a promotion engine and a candidate local offer.
+
+### Inputs
+
+Only the minimum context required for the decision:
+
+- coarse region, city, postal region, or approved radius bucket;
+- advertiser service area or eligible location set;
+- campaign category and delivery constraints;
+- consent and policy flags;
+- optional temporary session context;
+- emergency-priority state when applicable.
+
+### Outputs
+
+A minimal response:
+
+```json
+{
+  "decision": "eligible",
+  "reason_code": "LOCAL_SERVICE_AREA_MATCH",
+  "region_bucket": "US-WA-EASTERN-25MI",
+  "expires_at": "2026-07-19T06:15:00Z",
+  "receipt_hash": "sha256:..."
+}
+```
+
+The platform remains responsible for its auction, ranking, creative selection, frequency controls, billing, and final presentation decision.
+
+## Privacy boundary
+
+The pilot must fail closed unless the following controls are satisfied:
+
+- no MAC addresses;
+- no persistent hardware identifiers;
+- no raw location history;
+- no cross-app identity resolution;
+- no sale of individual location records;
+- no inference of sensitive traits;
+- no targeting of children;
+- no sensitive-category targeting without platform-approved policy review;
+- short-lived, non-unique locality tokens;
+- coarse geographic resolution by default;
+- explicit retention limits;
+- independently testable deletion and opt-out behavior;
+- aggregate reporting thresholds that prevent singling out individuals.
+
+## Fit with SKYGRID
+
+The SKYGRID Emergency Data On-Ramp remains the governing product: a secure HTTPS entry point where emergency, outage, responder, system-health, customer-impact, and continuity data is validated, logged, routed, proved, and surfaced to dashboards or trusted partners.
+
+The Local Relevance Layer is an optional commercial extension of the same controlled-routing and evidence principles. It must remain architecturally and contractually separated from emergency operations so advertising traffic cannot interfere with emergency intake, continuity routing, or responder workflows.
+
+## Emergency precedence
+
+A partner may optionally use the same relevance decision pattern to prioritize public-safety information ahead of commercial promotion when an authenticated emergency state is active.
+
+Examples:
+
+- wildfire evacuation zones;
+- road closures;
+- power and communications outages;
+- nearby shelters and medical resources;
+- verified local recovery services.
+
+Emergency precedence must be policy controlled, authenticated, auditable, and unavailable to ordinary advertisers.
+
+## Pilot integration models
+
+### Model A — Decision API
+
+The partner sends a coarse locality bucket and candidate service area. SKYGRID returns eligible, ineligible, or indeterminate.
+
+Best for controlled testing with an existing ad-serving or recommendation stack.
+
+### Model B — Campaign preflight
+
+SKYGRID reviews campaign location configuration before launch and flags mismatches, missing exclusions, unsupported service areas, and overly broad reach.
+
+Best for agencies, small-business campaign tools, and AI-assisted campaign creation.
+
+### Model C — Local inventory router
+
+A publisher or AI assistant submits a local-intent request. SKYGRID returns an approved pool of nearby offers without exposing an individual identity.
+
+Best for local discovery, neighborhood marketplaces, conversational commerce, and community media.
+
+## Ninety-day controlled pilot
+
+### Phase 1 — Design and policy
+
+- define partner-approved locality buckets;
+- complete privacy threat modeling;
+- document allowed and prohibited data;
+- agree retention, deletion, and audit requirements;
+- establish emergency/commercial traffic separation;
+- define baseline metrics.
+
+### Phase 2 — Shadow evaluation
+
+- run decisions without changing live ad delivery;
+- compare SKYGRID results with the partner's existing geo decision;
+- record false-positive and false-negative categories;
+- identify latency and availability requirements;
+- validate that receipts contain no personal data.
+
+### Phase 3 — Limited live experiment
+
+- restrict to consenting adults and non-sensitive local categories;
+- use a small geography and advertiser cohort;
+- apply platform-controlled holdouts;
+- enforce automatic rollback thresholds;
+- publish an aggregate pilot report.
+
+## Pilot success metrics
+
+The pilot should measure, not assume, commercial value.
+
+Primary metrics:
+
+- geographically impossible impression rate;
+- out-of-service-area click rate;
+- local conversion or visit-intent lift;
+- advertiser wasted-spend reduction;
+- user hide/report rate;
+- local-business participation rate;
+- incremental decision latency;
+- compute and delivery work avoided;
+- percentage of indeterminate decisions;
+- privacy and policy exceptions.
+
+No network-cost, revenue, conversion, or quality claim should be marketed as proven until measured in a controlled partner pilot.
+
+## Target partners
+
+### Google / YouTube
+
+Position as a preflight and verification layer for presence-only local campaigns, proximity campaigns, local inventory, and mismatch diagnostics.
+
+### Meta
+
+Position as a privacy-safe locality verification and campaign-quality layer that complements existing location targeting and conversion tooling without contributing a new personal identifier.
+
+### OpenAI and other AI-native promotion engines
+
+Position as a local commercial-context adapter for conversational discovery: nearby services, neighborhood merchants, local events, and service-area validation with explicit separation between sponsored content and organic answers.
+
+### Agencies and local-commerce platforms
+
+Use these as faster design partners before requesting integration into the largest promotion engines. A successful agency or regional-marketplace pilot can produce the evidence needed for enterprise review.
+
+## Commercial offer
+
+Recommended opening offer:
+
+- paid design-partner engagement;
+- fixed-fee privacy and integration assessment;
+- ninety-day controlled pilot;
+- usage-based decision pricing after validation;
+- optional enterprise license for on-premises or partner-controlled deployment;
+- no claim of exclusivity unless separately negotiated;
+- no transfer of SKYGRID core intellectual property in the pilot agreement.
+
+## Buyer-facing value statement
+
+SKYGRID helps promotion and AI platforms verify that local commercial content is geographically usable before presentation. It uses coarse, short-lived locality context rather than persistent device identity, returns a minimal decision and audit receipt, and is designed to reduce impossible impressions while giving neighborhood businesses a fairer route to nearby customers.
+
+## Required diligence before production
+
+- privacy counsel review;
+- platform advertising-policy review;
+- data-protection impact assessment where required;
+- security architecture review;
+- abuse and discrimination testing;
+- child-safety review;
+- sensitive-category exclusions;
+- load, latency, failover, and isolation testing;
+- independent verification of deletion and retention controls;
+- written agreement on ownership of measurements and derived data.
+
+## Current readiness statement
+
+This document defines a commercial pilot concept. It does not represent an operational integration with Google, YouTube, Meta, OpenAI, or any other advertising or AI platform. The module remains experimental until code, policy controls, tests, and partner validation are completed.


### PR DESCRIPTION
## Summary

Creates a commercially usable, privacy-first partner package for the proposed **SKYGRID Local Relevance Layer**.

## Included

- enterprise pilot brief;
- buyer-facing value proposition;
- privacy and representation boundaries;
- three integration models;
- ninety-day controlled-pilot structure;
- measurable success criteria;
- Google/YouTube, Meta, OpenAI/AI-native, agency, and regional-platform outreach language;
- discovery questions, objection handling, qualification criteria, and outreach sequence.

## Safety and product boundaries

- The **SKYGRID Emergency Data On-Ramp** remains the governing product name.
- The Local Relevance Layer is documented as an optional experimental commercial module.
- MAC addresses, persistent hardware identifiers, advertising IDs, raw location histories, and cross-app identity resolution are prohibited.
- Advertising and emergency traffic must remain isolated.
- No current integration or partnership with Google, YouTube, Meta, OpenAI, or another promotion engine is claimed.
- Savings, conversion, infrastructure, and quality improvements remain hypotheses until a controlled pilot measures them.

## Commercial next step

Use the package to recruit agency or regional-commerce design partners, produce shadow-pilot evidence, and then pursue official enterprise partner channels.

Closes #156 only after the technical demonstration, privacy threat model, measurement plan, and pilot statement of work are completed.