### PR TITLE
Add Aura Recon Companion dev-container scaffold

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "Aura Recon Companion",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/apps/aura-recon-companion",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "forwardPorts": [8000],
+  "portsAttributes": {
+    "8000": {
+      "label": "Aura Recon API",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install -r backend/requirements.txt",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "AURA_RECON_ENV": "codespaces"
+  }
+}

--- a/.github/workflows/aura-recon-companion.yml
+++ b/.github/workflows/aura-recon-companion.yml
@@ -1,0 +1,30 @@
+name: Aura Recon Companion
+
+on:
+  pull_request:
+    paths:
+      - '.devcontainer/**'
+      - 'apps/aura-recon-companion/**'
+      - '.github/workflows/aura-recon-companion.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/aura-recon-companion/backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: apps/aura-recon-companion/backend/requirements.txt
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Run tests
+        run: python -m pytest -q

--- a/apps/aura-recon-companion/README.md
+++ b/apps/aura-recon-companion/README.md
@@ -1,0 +1,100 @@
+# Aura Recon Companion
+
+Aura Recon Companion is an iPhone-oriented interface plus a bounded backend for reviewing public metadata about domains that the operator owns or is explicitly authorized to assess.
+
+[Open this branch in GitHub Codespaces](https://codespaces.new/MVPuknowme/Aura-core?ref=agent%2Faura-recon-companion-devcontainer&quickstart=1)
+
+## Current MVP
+
+- SwiftUI iOS client source generated from `ios/project.yml` with XcodeGen.
+- FastAPI development backend.
+- Explicit target-authorization confirmation.
+- Hostname-only validation.
+- Blocking of private, loopback, link-local, reserved, and other non-global targets.
+- DNS collection for A, AAAA, MX, NS, and TXT records.
+- Optional single HTTPS metadata request with selected response headers.
+- SHA-256 evidence digest for each result payload.
+- GitHub Codespaces/dev-container setup.
+- Automated backend tests.
+
+## Deliberate limits
+
+This release does not exploit services, brute-force paths, test passwords, enumerate private networks, execute arbitrary terminal commands, or claim SpiderFoot's full provider catalog. SpiderFoot-scale enrichment can be added later through an isolated adapter after provider credentials, terms, retention, and authorization controls are defined.
+
+The Codespaces link is a development environment, not an installable iPhone application. A TestFlight or App Store download link requires Apple Developer signing, an App Store Connect record, an archived build produced with Xcode on macOS, and Apple review where applicable.
+
+## Run in Codespaces
+
+The dev container installs the Python dependencies automatically. In the Codespaces terminal:
+
+```bash
+cd backend
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+Open the forwarded port and visit:
+
+- `/docs` for the interactive API console.
+- `/health` for service status.
+
+Example authorized request:
+
+```json
+{
+  "target": "example.com",
+  "authorized": true,
+  "profile": "dns-passive"
+}
+```
+
+## Run from PowerShell
+
+From `apps/aura-recon-companion`:
+
+```powershell
+.\scripts\Start-AuraRecon.ps1
+```
+
+Then verify:
+
+```powershell
+Invoke-RestMethod http://localhost:8000/health |
+    ConvertTo-Json -Depth 10
+```
+
+## Generate the iOS project
+
+On a Mac with Xcode and XcodeGen:
+
+```bash
+cd ios
+xcodegen generate
+open AuraReconCompanion.xcodeproj
+```
+
+Set your Apple development team and replace the development API URL with the HTTPS URL for your deployed backend. Localhost works in the iOS Simulator; a physical iPhone needs a reachable HTTPS development endpoint or a trusted local-network configuration.
+
+## Architecture
+
+```text
+iPhone SwiftUI client
+        |
+        | HTTPS JSON
+        v
+Authorization-gated FastAPI service
+        |-- target validation and SSRF guard
+        |-- bounded DNS collection
+        |-- optional HTTPS metadata request
+        |-- evidence digest
+        v
+Operator-reviewed report
+```
+
+## Next production milestones
+
+1. Add authenticated user sessions and per-user rate limits.
+2. Add durable encrypted report storage with deletion controls.
+3. Add a separately sandboxed SpiderFoot adapter for approved providers.
+4. Add accessibility and VoiceOver verification.
+5. Add an Xcode test target and macOS CI runner.
+6. Archive through Xcode and publish to TestFlight.

--- a/apps/aura-recon-companion/backend/app/__init__.py
+++ b/apps/aura-recon-companion/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Aura Recon Companion backend package."""

--- a/apps/aura-recon-companion/backend/app/main.py
+++ b/apps/aura-recon-companion/backend/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, HTTPException
+
+from .models import ScanReport, ScanRequest
+from .scanner import run_scan
+
+app = FastAPI(title="Aura Recon Companion API", version="0.1.0")
+
+
+@app.get("/health")
+def health() -> dict[str, object]:
+    return {
+        "ok": True,
+        "service": "aura-recon-companion",
+        "version": "0.1.0",
+        "profiles": ["dns-passive", "web-metadata"],
+    }
+
+
+@app.post("/api/v1/scans", response_model=ScanReport)
+def create_scan(request: ScanRequest) -> ScanReport:
+    try:
+        return run_scan(request)
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/apps/aura-recon-companion/backend/app/models.py
+++ b/apps/aura-recon-companion/backend/app/models.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ScanProfile(str, Enum):
+    DNS_PASSIVE = "dns-passive"
+    WEB_METADATA = "web-metadata"
+
+
+class ScanRequest(BaseModel):
+    target: str = Field(min_length=3, max_length=253)
+    authorized: bool
+    profile: ScanProfile = ScanProfile.DNS_PASSIVE
+
+    @field_validator("target")
+    @classmethod
+    def normalize_target(cls, value: str) -> str:
+        target = value.strip().lower().rstrip(".")
+        if "://" in target or "/" in target or "@" in target:
+            raise ValueError("Enter a hostname only, without a URL, path, or credentials")
+        return target
+
+
+class Finding(BaseModel):
+    category: str
+    source: str
+    value: Any
+
+
+class ScanReport(BaseModel):
+    scan_id: str
+    target: str
+    profile: ScanProfile
+    started_at: datetime
+    completed_at: datetime
+    findings: list[Finding]
+    evidence_sha256: str
+    limitations: list[str]

--- a/apps/aura-recon-companion/backend/app/scanner.py
+++ b/apps/aura-recon-companion/backend/app/scanner.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import socket
+import uuid
+from datetime import UTC, datetime
+
+import dns.exception
+import dns.resolver
+import httpx
+
+from .models import Finding, ScanProfile, ScanReport, ScanRequest
+
+_RECORD_TYPES = ("A", "AAAA", "MX", "NS", "TXT")
+_SELECTED_HEADERS = {
+    "content-type",
+    "content-length",
+    "server",
+    "strict-transport-security",
+    "content-security-policy",
+    "x-content-type-options",
+    "x-frame-options",
+    "referrer-policy",
+}
+
+
+def _validated_public_addresses(hostname: str) -> list[str]:
+    try:
+        entries = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"Target did not resolve: {exc}") from exc
+
+    addresses = sorted({entry[4][0] for entry in entries})
+    if not addresses:
+        raise ValueError("Target did not resolve to an address")
+
+    for raw in addresses:
+        address = ipaddress.ip_address(raw)
+        if not address.is_global:
+            raise ValueError("Private, loopback, link-local, reserved, and non-global targets are blocked")
+    return addresses
+
+
+def _dns_findings(target: str) -> list[Finding]:
+    findings: list[Finding] = []
+    resolver = dns.resolver.Resolver(configure=True)
+    resolver.lifetime = 5.0
+
+    for record_type in _RECORD_TYPES:
+        try:
+            answer = resolver.resolve(target, record_type, raise_on_no_answer=False)
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers, dns.exception.Timeout):
+            continue
+        except dns.resolver.NoAnswer:
+            continue
+
+        values = [item.to_text() for item in answer]
+        if values:
+            findings.append(
+                Finding(category="dns", source=record_type, value=values)
+            )
+    return findings
+
+
+def _web_metadata_findings(target: str) -> list[Finding]:
+    url = f"https://{target}/"
+    with httpx.Client(
+        timeout=httpx.Timeout(8.0, connect=5.0),
+        follow_redirects=False,
+        headers={"User-Agent": "Aura-Recon-Companion/0.1 authorized-metadata-check"},
+    ) as client:
+        response = client.head(url)
+
+    headers = {
+        key.lower(): value
+        for key, value in response.headers.items()
+        if key.lower() in _SELECTED_HEADERS
+    }
+    findings = [
+        Finding(category="web", source="status", value=response.status_code),
+        Finding(category="web", source="headers", value=headers),
+    ]
+    if "location" in response.headers:
+        findings.append(
+            Finding(category="web", source="redirect-location", value=response.headers["location"])
+        )
+    return findings
+
+
+def run_scan(request: ScanRequest) -> ScanReport:
+    if not request.authorized:
+        raise PermissionError("You must confirm that you own or are authorized to assess the target")
+
+    started_at = datetime.now(UTC)
+    public_addresses = _validated_public_addresses(request.target)
+    findings: list[Finding] = [
+        Finding(category="resolution", source="system", value=public_addresses)
+    ]
+    findings.extend(_dns_findings(request.target))
+
+    limitations = [
+        "This baseline collects DNS records and, when selected, one HTTPS metadata request.",
+        "It does not exploit services, brute-force paths, test credentials, or prove a vulnerability.",
+        "SpiderFoot-scale enrichment requires separately configured providers and API credentials.",
+    ]
+
+    if request.profile == ScanProfile.WEB_METADATA:
+        try:
+            findings.extend(_web_metadata_findings(request.target))
+        except httpx.HTTPError as exc:
+            findings.append(Finding(category="web", source="error", value=str(exc)))
+
+    completed_at = datetime.now(UTC)
+    scan_id = str(uuid.uuid4())
+    evidence_payload = {
+        "scan_id": scan_id,
+        "target": request.target,
+        "profile": request.profile.value,
+        "started_at": started_at.isoformat(),
+        "completed_at": completed_at.isoformat(),
+        "findings": [finding.model_dump(mode="json") for finding in findings],
+    }
+    evidence_sha256 = hashlib.sha256(
+        json.dumps(evidence_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    return ScanReport(
+        scan_id=scan_id,
+        target=request.target,
+        profile=request.profile,
+        started_at=started_at,
+        completed_at=completed_at,
+        findings=findings,
+        evidence_sha256=evidence_sha256,
+        limitations=limitations,
+    )

--- a/apps/aura-recon-companion/backend/requirements.txt
+++ b/apps/aura-recon-companion/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+pydantic==2.11.7
+dnspython==2.7.0
+httpx==0.28.1
+pytest==8.4.1

--- a/apps/aura-recon-companion/backend/requirements.txt
+++ b/apps/aura-recon-companion/backend/requirements.txt
@@ -1,6 +1,6 @@
-fastapi==0.116.1
-uvicorn[standard]==0.35.0
-pydantic==2.11.7
-dnspython==2.7.0
-httpx==0.28.1
-pytest==8.4.1
+fastapi>=0.138,<0.139
+uvicorn[standard]>=0.51,<0.52
+pydantic>=2.12,<3
+dnspython>=2.8,<3
+httpx>=0.28,<0.29
+pytest>=8.4,<9

--- a/apps/aura-recon-companion/backend/tests/test_api.py
+++ b/apps/aura-recon-companion/backend/tests/test_api.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+def test_scan_requires_authorization() -> None:
+    response = client.post(
+        "/api/v1/scans",
+        json={"target": "example.com", "authorized": False, "profile": "dns-passive"},
+    )
+    assert response.status_code == 403
+
+
+def test_rejects_url_in_target() -> None:
+    response = client.post(
+        "/api/v1/scans",
+        json={"target": "https://example.com/path", "authorized": True, "profile": "dns-passive"},
+    )
+    assert response.status_code == 422

--- a/apps/aura-recon-companion/ios/AuraReconCompanion/App/AuraReconCompanionApp.swift
+++ b/apps/aura-recon-companion/ios/AuraReconCompanion/App/AuraReconCompanionApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AuraReconCompanionApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/apps/aura-recon-companion/ios/AuraReconCompanion/Models/ScanModels.swift
+++ b/apps/aura-recon-companion/ios/AuraReconCompanion/Models/ScanModels.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+enum ScanProfile: String, Codable, CaseIterable, Identifiable {
+    case dnsPassive = "dns-passive"
+    case webMetadata = "web-metadata"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .dnsPassive: return "DNS passive"
+        case .webMetadata: return "DNS + HTTPS metadata"
+        }
+    }
+}
+
+struct ScanRequest: Codable {
+    let target: String
+    let authorized: Bool
+    let profile: ScanProfile
+}
+
+struct Finding: Codable, Identifiable {
+    let category: String
+    let source: String
+    let value: JSONValue
+
+    var id: String { "\(category)-\(source)-\(value.description)" }
+}
+
+struct ScanReport: Codable {
+    let scanID: String
+    let target: String
+    let profile: ScanProfile
+    let startedAt: Date
+    let completedAt: Date
+    let findings: [Finding]
+    let evidenceSHA256: String
+    let limitations: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case scanID = "scan_id"
+        case target
+        case profile
+        case startedAt = "started_at"
+        case completedAt = "completed_at"
+        case findings
+        case evidenceSHA256 = "evidence_sha256"
+        case limitations
+    }
+}
+
+enum JSONValue: Codable, CustomStringConvertible {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let value = try? container.decode(Bool.self) { self = .bool(value) }
+        else if let value = try? container.decode(Double.self) { self = .number(value) }
+        else if let value = try? container.decode(String.self) { self = .string(value) }
+        else if let value = try? container.decode([String: JSONValue].self) { self = .object(value) }
+        else { self = .array(try container.decode([JSONValue].self)) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .string(let value): return value
+        case .number(let value): return String(value)
+        case .bool(let value): return String(value)
+        case .object(let value): return value.map { "\($0): \($1.description)" }.sorted().joined(separator: "\n")
+        case .array(let value): return value.map(\.description).joined(separator: "\n")
+        case .null: return "null"
+        }
+    }
+}

--- a/apps/aura-recon-companion/ios/AuraReconCompanion/Services/APIClient.swift
+++ b/apps/aura-recon-companion/ios/AuraReconCompanion/Services/APIClient.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+actor APIClient {
+    static let shared = APIClient()
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init() {
+        encoder = JSONEncoder()
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func runScan(
+        target: String,
+        authorized: Bool,
+        profile: ScanProfile,
+        baseURL: URL
+    ) async throws -> ScanReport {
+        let endpoint = baseURL.appending(path: "api/v1/scans")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 20
+        request.httpBody = try encoder.encode(
+            ScanRequest(target: target, authorized: authorized, profile: profile)
+        )
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let message = String(data: data, encoding: .utf8) ?? "Request failed"
+            throw APIError.server(status: http.statusCode, message: message)
+        }
+        return try decoder.decode(ScanReport.self, from: data)
+    }
+}
+
+enum APIError: LocalizedError {
+    case server(status: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .server(let status, let message):
+            return "Server returned \(status): \(message)"
+        }
+    }
+}

--- a/apps/aura-recon-companion/ios/AuraReconCompanion/Views/ContentView.swift
+++ b/apps/aura-recon-companion/ios/AuraReconCompanion/Views/ContentView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var target = "example.com"
+    @State private var endpoint = "http://127.0.0.1:8000/"
+    @State private var profile: ScanProfile = .dnsPassive
+    @State private var authorized = false
+    @State private var report: ScanReport?
+    @State private var errorMessage: String?
+    @State private var isLoading = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Authorized target") {
+                    TextField("example.com", text: $target)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    Picker("Profile", selection: $profile) {
+                        ForEach(ScanProfile.allCases) { item in
+                            Text(item.title).tag(item)
+                        }
+                    }
+                    Toggle(
+                        "I own this target or have explicit permission to assess it.",
+                        isOn: $authorized
+                    )
+                }
+
+                Section("Development API") {
+                    TextField("https://your-api.example/", text: $endpoint)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+
+                Section {
+                    Button {
+                        Task { await runScan() }
+                    } label: {
+                        HStack {
+                            if isLoading { ProgressView() }
+                            Text(isLoading ? "Running…" : "Run bounded scan")
+                        }
+                    }
+                    .disabled(isLoading || !authorized || target.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+
+                if let errorMessage {
+                    Section("Error") {
+                        Text(errorMessage).foregroundStyle(.red)
+                    }
+                }
+
+                if let report {
+                    Section("Evidence") {
+                        LabeledContent("Target", value: report.target)
+                        LabeledContent("Profile", value: report.profile.title)
+                        Text(report.evidenceSHA256)
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                    }
+
+                    Section("Findings") {
+                        ForEach(report.findings) { finding in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("\(finding.category) · \(finding.source)")
+                                    .font(.headline)
+                                Text(finding.value.description)
+                                    .font(.caption.monospaced())
+                                    .textSelection(.enabled)
+                            }
+                        }
+                    }
+
+                    Section("Limitations") {
+                        ForEach(report.limitations, id: \.self) { limitation in
+                            Text(limitation)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Aura Recon")
+        }
+    }
+
+    @MainActor
+    private func runScan() async {
+        isLoading = true
+        errorMessage = nil
+        report = nil
+        defer { isLoading = false }
+
+        guard let baseURL = URL(string: endpoint) else {
+            errorMessage = "Enter a valid API URL."
+            return
+        }
+
+        do {
+            report = try await APIClient.shared.runScan(
+                target: target,
+                authorized: authorized,
+                profile: profile,
+                baseURL: baseURL
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/apps/aura-recon-companion/ios/project.yml
+++ b/apps/aura-recon-companion/ios/project.yml
@@ -1,0 +1,23 @@
+name: AuraReconCompanion
+options:
+  bundleIdPrefix: com.mvpuknowme
+  deploymentTarget:
+    iOS: "17.0"
+settings:
+  base:
+    SWIFT_VERSION: "5.10"
+targets:
+  AuraReconCompanion:
+    type: application
+    platform: iOS
+    sources:
+      - AuraReconCompanion
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.mvpuknowme.aurareconcompanion
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_CFBundleDisplayName: Aura Recon
+        INFOPLIST_KEY_NSLocalNetworkUsageDescription: Aura Recon connects to your authorized development API during local testing.
+        INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking: YES
+    scheme:
+      testTargets: []

--- a/apps/aura-recon-companion/scripts/Start-AuraRecon.ps1
+++ b/apps/aura-recon-companion/scripts/Start-AuraRecon.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+$BackendRoot = Join-Path $ProjectRoot 'backend'
+
+Set-Location $BackendRoot
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    throw 'Python 3.12 or newer is required.'
+}
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary

Adds the first development scaffold for **Aura Recon Companion**: a SwiftUI iPhone client source tree and a bounded FastAPI service that can run in GitHub Codespaces.

## Included

- one-click Codespaces/dev-container configuration
- SwiftUI app source and XcodeGen project definition
- authorization confirmation before any target request
- hostname-only input validation
- blocking for private, loopback, link-local, reserved, and other non-global targets
- bounded DNS record collection
- optional single HTTPS metadata request
- SHA-256 evidence digest generation
- PowerShell startup script
- backend tests and path-scoped GitHub Actions workflow

## Security boundaries

- no exploitation, credential testing, path brute forcing, arbitrary terminal execution, or private-network enumeration
- no claim of full SpiderFoot module parity in this first scaffold
- SpiderFoot-scale provider integrations remain a separately sandboxed follow-up
- no production deployment or Vercel configuration changes

## Distribution boundary

The Codespaces link is available immediately for development. A physical-iPhone download link still requires Apple signing, Xcode archive, App Store Connect/TestFlight configuration, and Apple review where applicable.

## Validation

The branch includes a Python 3.12 GitHub Actions test job. Local validation from the assistant container was blocked because that container could not resolve GitHub; the PR checks are the source of truth.