### PR TITLE
Add verified infrastructure revenue ledger

### DIFF
--- a/configs/accounting/verified-revenue-ledger.sample.json
+++ b/configs/accounting/verified-revenue-ledger.sample.json
@@ -1,0 +1,27 @@
+{
+  "ledger_id": "skygrid-verified-infrastructure-revenue-v1",
+  "entries": [
+    {
+      "entry_id": "example-staking-reward",
+      "occurred_at": "2026-08-04T00:00:00.000Z",
+      "network": "ethereum",
+      "role": "validator",
+      "category": "staking",
+      "amount_usd": 0,
+      "evidence_state": "unverified",
+      "evidence_refs": [],
+      "notes": "Replace with a real withdrawal or reward record before recognizing income."
+    },
+    {
+      "entry_id": "example-hosting-cost",
+      "occurred_at": "2026-08-04T00:00:00.000Z",
+      "network": "skygrid",
+      "role": "infrastructure",
+      "category": "operating_cost",
+      "amount_usd": 0,
+      "evidence_state": "unverified",
+      "evidence_refs": [],
+      "notes": "Replace with a reconciled cloud, bandwidth, hardware, or transaction-cost record."
+    }
+  ]
+}

--- a/docs/accounting/verified-infrastructure-revenue-ledger.md
+++ b/docs/accounting/verified-infrastructure-revenue-ledger.md
@@ -1,0 +1,48 @@
+# SKYGRID Verified Infrastructure Revenue Ledger
+
+This ledger records revenue and operating costs for Aura-Core and the SKYGRID Emergency Data On-Ramp without treating projections as realized income.
+
+## Accounting rule
+
+Only entries with `evidence_state` equal to `verified` or `reconciled` contribute to net verified income. Estimated and unverified amounts remain visible but are excluded from the verified total.
+
+## Categories
+
+- `staking`: protocol rewards attributable to an actual validator or delegated position.
+- `infrastructure`: paid RPC, node hosting, compute lease, bandwidth, or managed-service revenue.
+- `protocol`: proving, sequencing, relaying, routing, or other protocol-specific payouts.
+- `treasury`: realized investment income attributable to a treasury position.
+- `operating_cost`: cloud, hardware, bandwidth, voting, gas, or other attributable expenses.
+
+## Evidence states
+
+- `verified`: supported by primary evidence such as a transaction, withdrawal, invoice, or payment record.
+- `reconciled`: verified against both the source event and the receiving ledger or account.
+- `estimated`: forecast or scenario value.
+- `unverified`: declared value without sufficient evidence.
+
+Verified and reconciled entries require at least one `evidence_refs` item. Never store private keys, seed phrases, full bank credentials, or secrets in evidence references.
+
+## Commands
+
+```powershell
+pnpm run revenue:ledger:test
+pnpm run revenue:ledger:verify
+node scripts/skygrid-revenue-ledger.mjs .\path\to\ledger.json
+```
+
+The default verification command reads `configs/accounting/verified-revenue-ledger.sample.json`.
+
+## Output
+
+The verifier reports:
+
+- verified and reconciled revenue;
+- verified operating costs;
+- net verified income;
+- estimated and unverified revenue excluded from verified income;
+- signed contributions grouped by category and network.
+
+## Integration boundary
+
+A running node is not automatically an income-producing validator. Each entry must identify the actual network role and evidence supporting the revenue or cost.

--- a/lib/accounting/verified-revenue-ledger.mjs
+++ b/lib/accounting/verified-revenue-ledger.mjs
@@ -1,0 +1,115 @@
+const EVIDENCE_STATES = new Set(["verified", "reconciled", "estimated", "unverified"]);
+const REVENUE_CATEGORIES = new Set([
+  "staking",
+  "infrastructure",
+  "protocol",
+  "treasury",
+  "operating_cost"
+]);
+
+function finiteNumber(value, field) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new TypeError(`${field} must be a finite number`);
+  }
+  return parsed;
+}
+
+export function validateLedgerEntry(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new TypeError("ledger entry must be an object");
+  }
+
+  const requiredStrings = ["entry_id", "occurred_at", "network", "role", "category", "evidence_state"];
+  for (const field of requiredStrings) {
+    if (typeof entry[field] !== "string" || entry[field].trim() === "") {
+      throw new TypeError(`${field} must be a non-empty string`);
+    }
+  }
+
+  if (!REVENUE_CATEGORIES.has(entry.category)) {
+    throw new TypeError(`unsupported category: ${entry.category}`);
+  }
+  if (!EVIDENCE_STATES.has(entry.evidence_state)) {
+    throw new TypeError(`unsupported evidence_state: ${entry.evidence_state}`);
+  }
+
+  const amountUsd = finiteNumber(entry.amount_usd, "amount_usd");
+  if (amountUsd < 0) {
+    throw new RangeError("amount_usd must be non-negative; use operating_cost for expenses");
+  }
+
+  if (entry.evidence_state === "verified" || entry.evidence_state === "reconciled") {
+    if (!Array.isArray(entry.evidence_refs) || entry.evidence_refs.length === 0) {
+      throw new TypeError("verified or reconciled entries require evidence_refs");
+    }
+  }
+
+  return {
+    ...entry,
+    amount_usd: amountUsd,
+    evidence_refs: Array.isArray(entry.evidence_refs) ? entry.evidence_refs : []
+  };
+}
+
+export function summarizeRevenueLedger(entries) {
+  if (!Array.isArray(entries)) {
+    throw new TypeError("entries must be an array");
+  }
+
+  const normalized = entries.map(validateLedgerEntry);
+  const totals = {
+    verified_revenue_usd: 0,
+    reconciled_revenue_usd: 0,
+    estimated_revenue_usd: 0,
+    unverified_revenue_usd: 0,
+    verified_operating_cost_usd: 0,
+    net_verified_income_usd: 0
+  };
+
+  const byCategory = {};
+  const byNetwork = {};
+
+  for (const entry of normalized) {
+    const isCost = entry.category === "operating_cost";
+    const key = `${entry.evidence_state}_revenue_usd`;
+
+    if (isCost) {
+      if (entry.evidence_state === "verified" || entry.evidence_state === "reconciled") {
+        totals.verified_operating_cost_usd += entry.amount_usd;
+      }
+    } else if (key in totals) {
+      totals[key] += entry.amount_usd;
+    }
+
+    byCategory[entry.category] ??= { verified_usd: 0, projected_usd: 0 };
+    byNetwork[entry.network] ??= { verified_usd: 0, projected_usd: 0 };
+
+    const target = entry.evidence_state === "verified" || entry.evidence_state === "reconciled"
+      ? "verified_usd"
+      : "projected_usd";
+    const signedAmount = isCost ? -entry.amount_usd : entry.amount_usd;
+    byCategory[entry.category][target] += signedAmount;
+    byNetwork[entry.network][target] += signedAmount;
+  }
+
+  totals.net_verified_income_usd =
+    totals.verified_revenue_usd +
+    totals.reconciled_revenue_usd -
+    totals.verified_operating_cost_usd;
+
+  return {
+    generated_at: new Date().toISOString(),
+    accounting_basis: "evidence-first",
+    entry_count: normalized.length,
+    totals,
+    by_category: byCategory,
+    by_network: byNetwork,
+    entries: normalized
+  };
+}
+
+export const ledgerEnums = {
+  evidence_states: [...EVIDENCE_STATES],
+  revenue_categories: [...REVENUE_CATEGORIES]
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
         "intake:policy-test": "node --test tests/skygrid-intake-policy-core.test.mjs",
         "capacity:lease-test": "node --test tests/skygrid-capacity-lease.test.mjs",
         "capacity:lease-verify": "npm run pnpk:validate && npm run capacity:lease-test",
+        "revenue:ledger:test": "node --test tests/verified-revenue-ledger.test.mjs",
+        "revenue:ledger:verify": "node scripts/skygrid-revenue-ledger.mjs",
         "aura:selection:watch": "node scripts/aura-core-ai-selection-watch.mjs",
         "mcp:check": "node scripts/check-mcp-sdk.mjs",
         "emergency:gate": "node scripts/skygrid-emergency-gate.mjs",

--- a/scripts/skygrid-revenue-ledger.mjs
+++ b/scripts/skygrid-revenue-ledger.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { summarizeRevenueLedger } from "../lib/accounting/verified-revenue-ledger.mjs";
+
+const inputPath = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(process.cwd(), "configs", "accounting", "verified-revenue-ledger.sample.json");
+
+async function writeStepSummary(report) {
+  if (!process.env.GITHUB_STEP_SUMMARY) return;
+
+  const totals = report.totals;
+  const rows = Object.entries(report.by_network)
+    .map(([network, values]) => `| ${network} | $${values.verified_usd.toFixed(2)} | $${values.projected_usd.toFixed(2)} |`)
+    .join("\n");
+
+  await fs.appendFile(
+    process.env.GITHUB_STEP_SUMMARY,
+    `# SKYGRID Verified Infrastructure Revenue Ledger\n\n` +
+      `- Net verified income: **$${totals.net_verified_income_usd.toFixed(2)}**\n` +
+      `- Verified operating costs: **$${totals.verified_operating_cost_usd.toFixed(2)}**\n` +
+      `- Estimated revenue excluded from verified income: **$${totals.estimated_revenue_usd.toFixed(2)}**\n\n` +
+      `| Network | Verified net contribution | Projected net contribution |\n|---|---:|---:|\n${rows}\n`
+  );
+}
+
+async function main() {
+  const document = JSON.parse(await fs.readFile(inputPath, "utf8"));
+  if (!Array.isArray(document.entries)) {
+    throw new TypeError("ledger document must contain an entries array");
+  }
+
+  const report = summarizeRevenueLedger(document.entries);
+  console.log(JSON.stringify(report, null, 2));
+  await writeStepSummary(report);
+}
+
+main().catch((error) => {
+  console.error(`Revenue ledger verification failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/tests/verified-revenue-ledger.test.mjs
+++ b/tests/verified-revenue-ledger.test.mjs
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  summarizeRevenueLedger,
+  validateLedgerEntry
+} from "../lib/accounting/verified-revenue-ledger.mjs";
+
+function entry(overrides = {}) {
+  return {
+    entry_id: "entry-1",
+    occurred_at: "2026-08-04T00:00:00.000Z",
+    network: "ethereum",
+    role: "validator",
+    category: "staking",
+    amount_usd: 100,
+    evidence_state: "verified",
+    evidence_refs: ["tx:0xabc"],
+    ...overrides
+  };
+}
+
+test("verified revenue is reduced by verified operating costs", () => {
+  const report = summarizeRevenueLedger([
+    entry(),
+    entry({
+      entry_id: "cost-1",
+      network: "aws",
+      role: "infrastructure",
+      category: "operating_cost",
+      amount_usd: 35,
+      evidence_refs: ["invoice:aws-2026-08"]
+    })
+  ]);
+
+  assert.equal(report.totals.verified_revenue_usd, 100);
+  assert.equal(report.totals.verified_operating_cost_usd, 35);
+  assert.equal(report.totals.net_verified_income_usd, 65);
+});
+
+test("estimated revenue is excluded from verified income", () => {
+  const report = summarizeRevenueLedger([
+    entry({ evidence_state: "estimated", evidence_refs: [], amount_usd: 500 })
+  ]);
+
+  assert.equal(report.totals.estimated_revenue_usd, 500);
+  assert.equal(report.totals.net_verified_income_usd, 0);
+});
+
+test("verified entries require evidence references", () => {
+  assert.throws(
+    () => validateLedgerEntry(entry({ evidence_refs: [] })),
+    /require evidence_refs/
+  );
+});
+
+test("expenses must use operating_cost instead of negative values", () => {
+  assert.throws(
+    () => validateLedgerEntry(entry({ amount_usd: -1 })),
+    /must be non-negative/
+  );
+});


### PR DESCRIPTION
## What changed

- Added an evidence-first revenue ledger core for SKYGRID/Aura-Core.
- Added categories for staking, infrastructure, protocol, treasury, and operating costs.
- Added evidence states for verified, reconciled, estimated, and unverified records.
- Excluded estimated and unverified amounts from net verified income.
- Required evidence references for verified and reconciled entries.
- Added a CLI verifier with GitHub Step Summary output.
- Added a safe zero-value sample ledger and Node test coverage.
- Added PowerShell-friendly commands and accounting documentation.

## Why

The earlier validator dashboard could imply income without proving the network role, payout source, or payment evidence. This change makes the existing clean-accounting rule executable and prevents projections from being represented as realized revenue.

## Validation

The branch includes:

- `pnpm run revenue:ledger:test`
- `pnpm run revenue:ledger:verify`

These checks have been added but were not executed through the GitHub connector, so CI or a local Node 24 run should confirm them before merge.

## Safety

- No wallet secrets, private keys, seed phrases, or bank credentials are stored.
- The sample ledger starts at zero and recognizes no income.
- Negative amounts are rejected; expenses must be classified explicitly as `operating_cost`.
