### PR TITLE
feat: add SKYGRID verified infrastructure revenue ledger

### DIFF
--- a/.github/workflows/skygrid-revenue-ledger-ci.yml
+++ b/.github/workflows/skygrid-revenue-ledger-ci.yml
@@ -1,0 +1,46 @@
+name: SKYGRID Revenue Ledger CI
+
+on:
+  pull_request:
+    paths:
+      - "lib/skygrid-revenue-ledger.mjs"
+      - "api/skygrid/revenue.mjs"
+      - "tests/skygrid-revenue-ledger.test.mjs"
+      - "schemas/skygrid-infrastructure-revenue.schema.json"
+      - "package.json"
+      - ".github/workflows/skygrid-revenue-ledger-ci.yml"
+  push:
+    branches:
+      - MVPuknowme
+    paths:
+      - "lib/skygrid-revenue-ledger.mjs"
+      - "api/skygrid/revenue.mjs"
+      - "tests/skygrid-revenue-ledger.test.mjs"
+      - "schemas/skygrid-infrastructure-revenue.schema.json"
+      - "package.json"
+
+permissions:
+  contents: read
+
+jobs:
+  revenue-ledger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Syntax check
+        run: |
+          node --check lib/skygrid-revenue-ledger.mjs
+          node --check api/skygrid/revenue.mjs
+          node --check tests/skygrid-revenue-ledger.test.mjs
+
+      - name: Revenue ledger tests
+        run: npm run revenue:ledger:test

--- a/api/skygrid/revenue.mjs
+++ b/api/skygrid/revenue.mjs
@@ -1,0 +1,78 @@
+import {
+  SKYGRID_REVENUE_LEDGER_ENUMS,
+  summarizeRevenueLedger
+} from "../../lib/skygrid-revenue-ledger.mjs";
+
+const PRODUCT = "SKYGRID Emergency Data On-Ramp";
+const ROUTE = "/api/skygrid/revenue";
+
+function applyHeaders(res) {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-SKYGRID-Product", PRODUCT);
+  res.setHeader("X-SKYGRID-Accounting", "evidence-first-fail-closed");
+}
+
+function respond(res, status, body) {
+  return res.status(status).json({
+    ...body,
+    product: PRODUCT,
+    route: ROUTE,
+    timestamp: new Date().toISOString()
+  });
+}
+
+export default async function handler(req, res) {
+  applyHeaders(res);
+
+  if (req.method === "GET") {
+    return respond(res, 200, {
+      ok: true,
+      mode: "contract",
+      ledger: summarizeRevenueLedger([]),
+      accepted_values: SKYGRID_REVENUE_LEDGER_ENUMS,
+      note: "GET exposes the accounting contract only. Submit records with POST for stateless verification and aggregation. No wallet signing or transaction execution occurs."
+    });
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "GET, POST");
+    return respond(res, 405, {
+      ok: false,
+      error: "method_not_allowed",
+      allowed: ["GET", "POST"]
+    });
+  }
+
+  const body = req.body && typeof req.body === "object" ? req.body : {};
+  const records = body.records;
+
+  if (!Array.isArray(records)) {
+    return respond(res, 400, {
+      ok: false,
+      error: "records_array_required"
+    });
+  }
+
+  if (records.length > 1000) {
+    return respond(res, 413, {
+      ok: false,
+      error: "ledger_batch_too_large",
+      max_records: 1000
+    });
+  }
+
+  try {
+    const ledger = summarizeRevenueLedger(records);
+    return respond(res, 200, {
+      ok: ledger.summary.rejected_records === 0,
+      mode: "verified_summary",
+      ledger
+    });
+  } catch (error) {
+    return respond(res, 400, {
+      ok: false,
+      error: "invalid_ledger_payload",
+      message: error instanceof Error ? error.message : String(error)
+    });
+  }
+}

--- a/api/skygrid/status.js
+++ b/api/skygrid/status.js
@@ -14,6 +14,7 @@ const ROUTES = [
   "/api/health",
   "/api/skygrid/status",
   "/api/skygrid/intake",
+  "/api/skygrid/revenue",
   "/api/highway/status",
   "/api/highway/postman",
   "/api/pay/quote?amount=25",
@@ -60,7 +61,8 @@ export default function handler(req, res) {
       production_failover: false,
       private_data_movement: false,
       wallet_signing: false,
-      transaction_broadcast: false
+      transaction_broadcast: false,
+      revenue_recognition: "evidence_first_fail_closed"
     },
     routes: ROUTES,
     timestamp: new Date().toISOString()

--- a/docs/accounting/skygrid-verified-infrastructure-revenue-ledger.md
+++ b/docs/accounting/skygrid-verified-infrastructure-revenue-ledger.md
@@ -1,0 +1,123 @@
+# SKYGRID Verified Infrastructure Revenue Ledger
+
+## Purpose
+
+The SKYGRID Verified Infrastructure Revenue Ledger provides an evidence-first accounting boundary for Aura-Core infrastructure, validator, staking, treasury, protocol, and capacity-lease economics.
+
+It exists to answer one question safely: **what income has actually been realized and supported by evidence?**
+
+The ledger must not treat a running node, forecast, token-price movement, reported validator output, or unverified claim as realized income.
+
+## Recognition states
+
+| State | Meaning | Included in net realized income? |
+|---|---|---|
+| `realized` | Income received or cost incurred with qualifying evidence | Yes |
+| `accrued` | Earned/incurred but not yet realized; evidence is required | No |
+| `unrealized` | Mark-to-market or other value change not converted into realized income | No |
+| `projected` | Forecast or scenario amount | No |
+| `unverified` | Reported amount without sufficient verification | No |
+
+## Income categories
+
+- `staking` — evidence-backed staking or validator rewards.
+- `infrastructure` — RPC, hosted node, compute, capacity lease, or other infrastructure service revenue.
+- `protocol` — proving, relaying, routing, sequencing, or other protocol-level compensation where SKYGRID has an evidenced entitlement.
+- `treasury` — realized treasury investment income. Unrealized token appreciation remains `unrealized`.
+
+## Cost categories
+
+- `protocol_fee`
+- `hosting`
+- `hardware_amortization`
+- `network_fee`
+- `other_operating`
+
+## Net realized income
+
+The canonical hard-number metric is:
+
+`net_realized_income_usd = realized_income_usd - realized_cost_usd`
+
+Only records that pass validation and contain qualifying evidence may enter the realized totals.
+
+## Qualifying evidence
+
+The v1 implementation accepts these evidence types:
+
+- `onchain_payout`
+- `staking_withdrawal`
+- `service_payment`
+- `signed_contract`
+- `capacity_lease`
+- `processor_event`
+- `bank_posting`
+- `cloud_billing`
+- `vendor_invoice`
+
+An evidence item contains at minimum a `type` and a `reference`. References should use transaction hashes, processor IDs, invoice IDs, contract identifiers, lease identifiers, or other auditable identifiers. Do not store private keys, seed phrases, bank credentials, or other secrets in ledger records.
+
+## API
+
+### `GET /api/skygrid/revenue`
+
+Returns the accounting contract, accepted enum values, and an empty ledger summary. It performs no financial actions.
+
+### `POST /api/skygrid/revenue`
+
+Accepts:
+
+```json
+{
+  "records": [
+    {
+      "id": "eth-withdrawal-2026-08-14-001",
+      "direction": "income",
+      "category": "staking",
+      "recognition": "realized",
+      "amount_usd": 125.50,
+      "network": "ethereum",
+      "asset": "ETH",
+      "evidence": [
+        {
+          "type": "staking_withdrawal",
+          "reference": "0x..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+The endpoint returns normalized records, rejected-record errors, category totals, evidence coverage, and realized/accrued/unrealized/projected/unverified totals.
+
+The endpoint is stateless in v1. It does not sign wallets, broadcast transactions, execute payouts, or persist submitted records.
+
+## Fail-closed controls
+
+A `realized` record without qualifying evidence is rejected and contributes `$0` to realized income or realized costs. An `accrued` record without evidence is also rejected. Invalid direction/category combinations and negative USD amounts are rejected.
+
+This deliberately favors understatement over unsupported revenue recognition.
+
+## Verification
+
+Run:
+
+```powershell
+npm run revenue:ledger:test
+```
+
+CI also runs syntax validation for the ledger core, API route, and tests.
+
+## Next adapters
+
+The ledger core is intentionally source-agnostic. Production adapters can later normalize evidence from:
+
+1. chain explorers / validator withdrawal data,
+2. capacity-lease payment receipts,
+3. Stripe or other processor events,
+4. AWS/cloud billing exports,
+5. bank reconciliation records,
+6. signed infrastructure contracts.
+
+Adapters should supply evidence to this ledger rather than bypassing its recognition controls.

--- a/lib/skygrid-revenue-ledger.mjs
+++ b/lib/skygrid-revenue-ledger.mjs
@@ -1,0 +1,213 @@
+const INCOME_CATEGORIES = new Set([
+  "staking",
+  "infrastructure",
+  "protocol",
+  "treasury"
+]);
+
+const COST_CATEGORIES = new Set([
+  "protocol_fee",
+  "hosting",
+  "hardware_amortization",
+  "network_fee",
+  "other_operating"
+]);
+
+const RECOGNITION_STATES = new Set([
+  "realized",
+  "accrued",
+  "unrealized",
+  "projected",
+  "unverified"
+]);
+
+const QUALIFYING_EVIDENCE_TYPES = new Set([
+  "onchain_payout",
+  "staking_withdrawal",
+  "service_payment",
+  "signed_contract",
+  "capacity_lease",
+  "processor_event",
+  "bank_posting",
+  "cloud_billing",
+  "vendor_invoice"
+]);
+
+function roundMoney(value) {
+  return Math.round((Number(value) + Number.EPSILON) * 100) / 100;
+}
+
+function nonNegativeMoney(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? roundMoney(parsed) : null;
+}
+
+function normalizeEvidence(evidence) {
+  if (!Array.isArray(evidence)) return [];
+
+  return evidence
+    .filter((item) => item && typeof item === "object")
+    .map((item) => ({
+      type: String(item.type || "").trim(),
+      reference: String(item.reference || "").trim(),
+      source: String(item.source || "").trim() || null,
+      observed_at: String(item.observed_at || "").trim() || null
+    }))
+    .filter((item) => item.type && item.reference);
+}
+
+function hasQualifyingEvidence(evidence) {
+  return evidence.some((item) => QUALIFYING_EVIDENCE_TYPES.has(item.type));
+}
+
+function validateRecord(record, index) {
+  const errors = [];
+  const id = String(record?.id || `record-${index + 1}`).trim();
+  const direction = String(record?.direction || "").trim();
+  const category = String(record?.category || "").trim();
+  const recognition = String(record?.recognition || "").trim();
+  const amountUsd = nonNegativeMoney(record?.amount_usd);
+  const evidence = normalizeEvidence(record?.evidence);
+
+  if (!id) errors.push("missing_id");
+  if (!new Set(["income", "cost"]).has(direction)) errors.push("invalid_direction");
+  if (!RECOGNITION_STATES.has(recognition)) errors.push("invalid_recognition");
+  if (amountUsd === null) errors.push("invalid_amount_usd");
+
+  if (direction === "income" && !INCOME_CATEGORIES.has(category)) {
+    errors.push("invalid_income_category");
+  }
+
+  if (direction === "cost" && !COST_CATEGORIES.has(category)) {
+    errors.push("invalid_cost_category");
+  }
+
+  const qualifyingEvidence = hasQualifyingEvidence(evidence);
+
+  if (recognition === "realized" && !qualifyingEvidence) {
+    errors.push("realized_requires_qualifying_evidence");
+  }
+
+  if (recognition === "accrued" && evidence.length === 0) {
+    errors.push("accrued_requires_evidence");
+  }
+
+  const accepted = errors.length === 0;
+
+  return {
+    id,
+    direction,
+    category,
+    recognition,
+    amount_usd: amountUsd,
+    currency: String(record?.currency || "USD").trim().toUpperCase(),
+    network: String(record?.network || "").trim() || null,
+    asset: String(record?.asset || "").trim() || null,
+    node_id: String(record?.node_id || "").trim() || null,
+    counterparty: String(record?.counterparty || "").trim() || null,
+    occurred_at: String(record?.occurred_at || "").trim() || null,
+    evidence,
+    evidence_verified: qualifyingEvidence,
+    accepted,
+    errors
+  };
+}
+
+function addMoney(summary, key, amount) {
+  summary[key] = roundMoney(summary[key] + Number(amount || 0));
+}
+
+export function summarizeRevenueLedger(records = []) {
+  if (!Array.isArray(records)) {
+    throw new TypeError("SKYGRID revenue ledger records must be an array.");
+  }
+
+  const normalized = records.map(validateRecord);
+  const accepted = normalized.filter((record) => record.accepted);
+  const rejected = normalized.filter((record) => !record.accepted);
+
+  const totals = {
+    realized_income_usd: 0,
+    realized_cost_usd: 0,
+    net_realized_income_usd: 0,
+    accrued_income_usd: 0,
+    accrued_cost_usd: 0,
+    unrealized_change_usd: 0,
+    projected_income_usd: 0,
+    projected_cost_usd: 0,
+    unverified_income_usd: 0,
+    unverified_cost_usd: 0
+  };
+
+  for (const record of accepted) {
+    const amount = record.amount_usd;
+
+    if (record.recognition === "realized") {
+      addMoney(totals, record.direction === "income" ? "realized_income_usd" : "realized_cost_usd", amount);
+      continue;
+    }
+
+    if (record.recognition === "accrued") {
+      addMoney(totals, record.direction === "income" ? "accrued_income_usd" : "accrued_cost_usd", amount);
+      continue;
+    }
+
+    if (record.recognition === "projected") {
+      addMoney(totals, record.direction === "income" ? "projected_income_usd" : "projected_cost_usd", amount);
+      continue;
+    }
+
+    if (record.recognition === "unverified") {
+      addMoney(totals, record.direction === "income" ? "unverified_income_usd" : "unverified_cost_usd", amount);
+      continue;
+    }
+
+    if (record.recognition === "unrealized") {
+      const signedAmount = record.direction === "income" ? amount : -amount;
+      addMoney(totals, "unrealized_change_usd", signedAmount);
+    }
+  }
+
+  totals.net_realized_income_usd = roundMoney(
+    totals.realized_income_usd - totals.realized_cost_usd
+  );
+
+  const byCategory = {};
+  for (const record of accepted.filter((item) => item.recognition === "realized")) {
+    const key = `${record.direction}:${record.category}`;
+    byCategory[key] = roundMoney((byCategory[key] || 0) + record.amount_usd);
+  }
+
+  const evidenceBackedRecords = accepted.filter((record) => record.evidence_verified).length;
+  const evidenceCoveragePct = accepted.length
+    ? roundMoney((evidenceBackedRecords / accepted.length) * 100)
+    : 0;
+
+  return {
+    ledger_version: "skygrid-verified-infrastructure-revenue-v1",
+    accounting_basis: "evidence_first_fail_closed",
+    generated_at: new Date().toISOString(),
+    summary: {
+      ...totals,
+      accepted_records: accepted.length,
+      rejected_records: rejected.length,
+      evidence_backed_records: evidenceBackedRecords,
+      evidence_coverage_pct: evidenceCoveragePct
+    },
+    realized_by_category_usd: byCategory,
+    records: normalized,
+    controls: {
+      recognized_income_rule: "Only accepted realized income with qualifying evidence is included in realized_income_usd.",
+      recognized_cost_rule: "Only accepted realized costs with qualifying evidence are included in realized_cost_usd.",
+      excluded_from_realized_net: ["accrued", "unrealized", "projected", "unverified"],
+      qualifying_evidence_types: [...QUALIFYING_EVIDENCE_TYPES]
+    }
+  };
+}
+
+export const SKYGRID_REVENUE_LEDGER_ENUMS = Object.freeze({
+  income_categories: [...INCOME_CATEGORIES],
+  cost_categories: [...COST_CATEGORIES],
+  recognition_states: [...RECOGNITION_STATES],
+  qualifying_evidence_types: [...QUALIFYING_EVIDENCE_TYPES]
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "intake:policy-test": "node --test tests/skygrid-intake-policy-core.test.mjs",
         "capacity:lease-test": "node --test tests/skygrid-capacity-lease.test.mjs",
         "capacity:lease-verify": "npm run pnpk:validate && npm run capacity:lease-test",
+        "revenue:ledger:test": "node --test tests/skygrid-revenue-ledger.test.mjs",
         "aura:selection:watch": "node scripts/aura-core-ai-selection-watch.mjs",
         "mcp:check": "node scripts/check-mcp-sdk.mjs",
         "emergency:gate": "node scripts/skygrid-emergency-gate.mjs",

--- a/schemas/skygrid-infrastructure-revenue.schema.json
+++ b/schemas/skygrid-infrastructure-revenue.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skygrid-protocol.net/schemas/skygrid-infrastructure-revenue.schema.json",
+  "title": "SKYGRID Verified Infrastructure Revenue Record",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "id",
+    "direction",
+    "category",
+    "recognition",
+    "amount_usd"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "direction": { "enum": ["income", "cost"] },
+    "category": {
+      "enum": [
+        "staking",
+        "infrastructure",
+        "protocol",
+        "treasury",
+        "protocol_fee",
+        "hosting",
+        "hardware_amortization",
+        "network_fee",
+        "other_operating"
+      ]
+    },
+    "recognition": {
+      "enum": ["realized", "accrued", "unrealized", "projected", "unverified"]
+    },
+    "amount_usd": { "type": "number", "minimum": 0 },
+    "currency": { "type": "string", "default": "USD" },
+    "network": { "type": ["string", "null"] },
+    "asset": { "type": ["string", "null"] },
+    "node_id": { "type": ["string", "null"] },
+    "counterparty": { "type": ["string", "null"] },
+    "occurred_at": { "type": ["string", "null"], "format": "date-time" },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "reference"],
+        "properties": {
+          "type": {
+            "enum": [
+              "onchain_payout",
+              "staking_withdrawal",
+              "service_payment",
+              "signed_contract",
+              "capacity_lease",
+              "processor_event",
+              "bank_posting",
+              "cloud_billing",
+              "vendor_invoice"
+            ]
+          },
+          "reference": { "type": "string", "minLength": 1 },
+          "source": { "type": ["string", "null"] },
+          "observed_at": { "type": ["string", "null"], "format": "date-time" }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "direction": { "const": "income" } } },
+      "then": {
+        "properties": {
+          "category": { "enum": ["staking", "infrastructure", "protocol", "treasury"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "direction": { "const": "cost" } } },
+      "then": {
+        "properties": {
+          "category": {
+            "enum": ["protocol_fee", "hosting", "hardware_amortization", "network_fee", "other_operating"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/skygrid-revenue-ledger.test.mjs
+++ b/tests/skygrid-revenue-ledger.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { summarizeRevenueLedger } from "../lib/skygrid-revenue-ledger.mjs";
+
+test("counts only evidence-backed realized income in realized net", () => {
+  const report = summarizeRevenueLedger([
+    {
+      id: "staking-withdrawal-1",
+      direction: "income",
+      category: "staking",
+      recognition: "realized",
+      amount_usd: 125.5,
+      network: "ethereum",
+      evidence: [
+        { type: "staking_withdrawal", reference: "0xabc" }
+      ]
+    },
+    {
+      id: "hosting-cost-1",
+      direction: "cost",
+      category: "hosting",
+      recognition: "realized",
+      amount_usd: 25.25,
+      evidence: [
+        { type: "cloud_billing", reference: "aws:invoice:123" }
+      ]
+    },
+    {
+      id: "projection-1",
+      direction: "income",
+      category: "infrastructure",
+      recognition: "projected",
+      amount_usd: 9000
+    }
+  ]);
+
+  assert.equal(report.summary.realized_income_usd, 125.5);
+  assert.equal(report.summary.realized_cost_usd, 25.25);
+  assert.equal(report.summary.net_realized_income_usd, 100.25);
+  assert.equal(report.summary.projected_income_usd, 9000);
+});
+
+test("rejects a realized amount that lacks qualifying evidence", () => {
+  const report = summarizeRevenueLedger([
+    {
+      id: "unsupported-realized-claim",
+      direction: "income",
+      category: "protocol",
+      recognition: "realized",
+      amount_usd: 100000,
+      evidence: []
+    }
+  ]);
+
+  assert.equal(report.summary.realized_income_usd, 0);
+  assert.equal(report.summary.rejected_records, 1);
+  assert.deepEqual(report.records[0].errors, ["realized_requires_qualifying_evidence"]);
+});
+
+test("keeps accrued, unrealized, projected, and unverified values outside realized net", () => {
+  const report = summarizeRevenueLedger([
+    {
+      id: "accrued-service",
+      direction: "income",
+      category: "infrastructure",
+      recognition: "accrued",
+      amount_usd: 300,
+      evidence: [{ type: "signed_contract", reference: "contract:001" }]
+    },
+    {
+      id: "treasury-gain",
+      direction: "income",
+      category: "treasury",
+      recognition: "unrealized",
+      amount_usd: 80
+    },
+    {
+      id: "forecast",
+      direction: "income",
+      category: "protocol",
+      recognition: "projected",
+      amount_usd: 500
+    },
+    {
+      id: "claim",
+      direction: "income",
+      category: "staking",
+      recognition: "unverified",
+      amount_usd: 700
+    }
+  ]);
+
+  assert.equal(report.summary.net_realized_income_usd, 0);
+  assert.equal(report.summary.accrued_income_usd, 300);
+  assert.equal(report.summary.unrealized_change_usd, 80);
+  assert.equal(report.summary.projected_income_usd, 500);
+  assert.equal(report.summary.unverified_income_usd, 700);
+});
+
+test("rejects invalid categories and negative amounts", () => {
+  const report = summarizeRevenueLedger([
+    {
+      id: "bad-record",
+      direction: "income",
+      category: "validator_magic",
+      recognition: "realized",
+      amount_usd: -10,
+      evidence: [{ type: "onchain_payout", reference: "0xdef" }]
+    }
+  ]);
+
+  assert.equal(report.summary.accepted_records, 0);
+  assert.equal(report.summary.rejected_records, 1);
+  assert.ok(report.records[0].errors.includes("invalid_amount_usd"));
+  assert.ok(report.records[0].errors.includes("invalid_income_category"));
+});


### PR DESCRIPTION
## Summary

Adds an evidence-first, fail-closed revenue ledger for SKYGRID/Aura-Core so hard-number infrastructure income is kept separate from accrued rewards, unrealized value changes, projections, and unverified claims.

## What changed

- adds `lib/skygrid-revenue-ledger.mjs` accounting core
- adds `GET/POST /api/skygrid/revenue` stateless verification/aggregation endpoint
- recognizes only evidence-backed `realized` income/costs in net realized income
- separates `accrued`, `unrealized`, `projected`, and `unverified` values
- adds explicit staking/infrastructure/protocol/treasury income categories and operating cost categories
- adds JSON Schema for revenue evidence records
- advertises the new route and fail-closed revenue recognition policy in `/api/skygrid/status`
- adds Node 24 CI and unit tests
- documents the accounting contract and future adapter boundaries

## Safety / accounting controls

- no wallet signing
- no transaction broadcasting
- no payout execution
- no persistence in v1
- realized values without qualifying evidence are rejected from totals
- accrued values require evidence and remain outside realized net
- projected and unverified amounts never enter realized income

## Verification

```powershell
npm run revenue:ledger:test
```

The dedicated `SKYGRID Revenue Ledger CI` workflow also runs syntax checks and this test suite for relevant PR changes.

## Follow-up

After this accounting boundary is reviewed, source adapters can feed it validator withdrawals, capacity-lease receipts, processor events, cloud costs, and reconciliation evidence without bypassing recognition controls.