### PR TITLE
Add guarded SKYGRID vault installer review build

### DIFF
--- a/.github/workflows/skygrid-vault-installer-review.yml
+++ b/.github/workflows/skygrid-vault-installer-review.yml
@@ -1,0 +1,51 @@
+name: SKYGRID vault installer review
+
+on:
+  pull_request:
+    paths:
+      - "packages/vault/src/install.ts"
+      - "packages/operator/src/vault-installer.ts"
+      - "api/admin/vault/**"
+      - ".github/workflows/skygrid-vault-installer-review.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  policy-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Type-check isolated installer boundary
+        run: >-
+          npx --yes --package typescript --package @types/node tsc
+          --noEmit
+          --strict
+          --skipLibCheck
+          --module NodeNext
+          --moduleResolution NodeNext
+          --target ES2022
+          --types node
+          packages/vault/src/install.ts
+          packages/operator/src/vault-installer.ts
+          api/admin/vault/_auth.ts
+          api/admin/vault/install-methods.ts
+          api/admin/vault/install.ts
+      - name: Enforce installer trust-boundary invariants
+        shell: pwsh
+        run: |
+          $files = @(
+            'packages/vault/src/install.ts',
+            'packages/operator/src/vault-installer.ts',
+            'api/admin/vault/install.ts'
+          )
+          $text = ($files | ForEach-Object { Get-Content $_ -Raw }) -join "`n"
+          if ($text -match 'shell\s*:\s*true') { throw 'shell:true is forbidden in vault installer paths' }
+          $route = Get-Content 'api/admin/vault/install.ts' -Raw
+          if ($route -match 'body\.(package|command|args|url)') { throw 'install route must not accept caller-supplied package/command/args/url' }
+          if ($route -notmatch 'methodId') { throw 'install route must resolve by canonical methodId' }
+          Write-Host 'SKYGRID vault installer trust boundary passed.'

--- a/api/admin/vault/_auth.ts
+++ b/api/admin/vault/_auth.ts
@@ -1,0 +1,53 @@
+import { timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export function requireOwner(
+  req: IncomingMessage,
+  res: ServerResponse,
+): boolean {
+  const configured = process.env.SKYGRID_OWNER_TOKEN;
+  if (!configured) {
+    sendJson(res, 503, {
+      ok: false,
+      error: "SKYGRID_OWNER_TOKEN is not configured; admin vault routes fail closed",
+    });
+    return false;
+  }
+
+  const authorization = req.headers.authorization ?? "";
+  const prefix = "Bearer ";
+  if (!authorization.startsWith(prefix)) {
+    sendJson(res, 401, { ok: false, error: "OWNER authorization required" });
+    return false;
+  }
+
+  const supplied = authorization.slice(prefix.length);
+  const a = Buffer.from(configured, "utf8");
+  const b = Buffer.from(supplied, "utf8");
+  const authorized = a.length === b.length && timingSafeEqual(a, b);
+  if (!authorized) {
+    sendJson(res, 403, { ok: false, error: "OWNER authorization rejected" });
+    return false;
+  }
+  return true;
+}
+
+export function sendJson(
+  res: ServerResponse,
+  statusCode: number,
+  body: Record<string, unknown>,
+): void {
+  res.statusCode = statusCode;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.setHeader("cache-control", "no-store");
+  res.end(JSON.stringify(body));
+}
+
+export async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  let body = "";
+  for await (const chunk of req) {
+    body += chunk.toString();
+    if (body.length > 16_384) throw new Error("request body too large");
+  }
+  return JSON.parse(body || "{}");
+}

--- a/api/admin/vault/install-methods.ts
+++ b/api/admin/vault/install-methods.ts
@@ -1,0 +1,62 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  currentPlatform,
+  type BackendId,
+  resolveRunnableMethods,
+} from "../../../packages/vault/src/install.js";
+import { requireOwner, sendJson } from "./_auth.js";
+
+const BACKENDS: readonly BackendId[] = [
+  "1password",
+  "bitwarden",
+  "protonpass",
+];
+
+export default async function handler(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method !== "GET") {
+    sendJson(res, 405, { ok: false, error: "method not allowed" });
+    return;
+  }
+  if (!requireOwner(req, res)) return;
+
+  const platform = currentPlatform();
+  if (!platform) {
+    sendJson(res, 200, {
+      ok: true,
+      enabled: true,
+      platform: process.platform,
+      methods: {},
+      warning: "Unsupported platform; automated installation is unavailable",
+    });
+    return;
+  }
+
+  const methods: Record<string, unknown> = {};
+  for (const backendId of BACKENDS) {
+    methods[backendId] = (await resolveRunnableMethods(backendId, platform)).map(
+      (method) =>
+        method.kind === "manual"
+          ? {
+              id: method.id,
+              kind: method.kind,
+              instructions: method.instructions,
+              url: method.url,
+            }
+          : {
+              id: method.id,
+              kind: method.kind,
+              executable: method.executable,
+            },
+    );
+  }
+
+  sendJson(res, 200, {
+    ok: true,
+    enabled: true,
+    platform,
+    methods,
+  });
+}

--- a/api/admin/vault/install.ts
+++ b/api/admin/vault/install.ts
@@ -1,0 +1,78 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  installVaultBackend,
+  isOperatorExecutionHost,
+} from "../../../packages/operator/src/vault-installer.js";
+import type { BackendId } from "../../../packages/vault/src/install.js";
+import { readJsonBody, requireOwner, sendJson } from "./_auth.js";
+
+const BACKENDS: readonly BackendId[] = [
+  "1password",
+  "bitwarden",
+  "protonpass",
+];
+
+function isBackendId(value: unknown): value is BackendId {
+  return typeof value === "string" && BACKENDS.includes(value as BackendId);
+}
+
+export default async function handler(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    sendJson(res, 405, { ok: false, error: "method not allowed" });
+    return;
+  }
+  if (!requireOwner(req, res)) return;
+  if (!isOperatorExecutionHost()) {
+    sendJson(res, 409, {
+      ok: false,
+      enabled: true,
+      executionAllowed: false,
+      error:
+        "Install API is enabled, but execution is blocked on CI/serverless runtimes; run it on a SKYGRID operator host",
+    });
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await readJsonBody(req);
+  } catch (error) {
+    sendJson(res, 400, {
+      ok: false,
+      error: error instanceof Error ? error.message : "invalid JSON body",
+    });
+    return;
+  }
+
+  const body = parsed as { backendId?: unknown; methodId?: unknown };
+  if (!isBackendId(body.backendId)) {
+    sendJson(res, 400, { ok: false, error: "invalid backendId" });
+    return;
+  }
+  if (typeof body.methodId !== "string" || body.methodId.length === 0) {
+    sendJson(res, 400, { ok: false, error: "methodId is required" });
+    return;
+  }
+
+  try {
+    const result = await installVaultBackend({
+      backendId: body.backendId,
+      methodId: body.methodId,
+      requestedBy: "OWNER",
+    });
+    sendJson(res, 200, {
+      ok: true,
+      enabled: true,
+      executionAllowed: true,
+      result,
+    });
+  } catch (error) {
+    sendJson(res, 500, {
+      ok: false,
+      error: error instanceof Error ? error.message : "installation failed",
+    });
+  }
+}

--- a/packages/operator/src/vault-installer.ts
+++ b/packages/operator/src/vault-installer.ts
@@ -1,0 +1,151 @@
+/**
+ * Guarded execution layer for SKYGRID vault-manager CLI installation.
+ *
+ * The caller supplies only canonical identifiers. Commands and argv are always
+ * reconstructed from packages/vault/src/install.ts.
+ */
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import {
+  buildInstallCommand,
+  currentPlatform,
+  type BackendId,
+  resetInstallerCache,
+  resolveAllowedInstallMethod,
+} from "../../vault/src/install.js";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_AUDIT_PATH = ".skygrid/audit/vault-installs.jsonl";
+
+export interface InstallRequest {
+  readonly backendId: BackendId;
+  readonly methodId: string;
+  readonly requestedBy: "OWNER";
+}
+
+export interface InstallResult {
+  readonly backendId: BackendId;
+  readonly methodId: string;
+  readonly platform: string;
+  readonly executable: string;
+  readonly commandHash: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export function isOperatorExecutionHost(): boolean {
+  if (process.env.SKYGRID_VAULT_INSTALL_EXECUTION === "disabled") return false;
+  if (process.env.CI === "true") return false;
+  if (process.env.VERCEL === "1") return false;
+  return true;
+}
+
+export async function installVaultBackend(
+  request: InstallRequest,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<InstallResult> {
+  if (!isOperatorExecutionHost()) {
+    throw new Error(
+      "Vault installation is enabled only on an operator host; execution is blocked in CI/serverless runtimes",
+    );
+  }
+
+  resetInstallerCache();
+  const method = await resolveAllowedInstallMethod(
+    request.backendId,
+    request.methodId,
+  );
+  const built = buildInstallCommand(method);
+  const platform = currentPlatform() ?? process.platform;
+  const commandHash = createHash("sha256")
+    .update(JSON.stringify([built.command, ...built.args]))
+    .digest("hex");
+
+  const result = await spawnAndCapture(built.command, built.args, timeoutMs);
+  const receipt: InstallResult = {
+    backendId: request.backendId,
+    methodId: request.methodId,
+    platform,
+    executable: method.executable,
+    commandHash,
+    exitCode: result.exitCode,
+    stdout: truncate(result.stdout),
+    stderr: truncate(result.stderr),
+  };
+
+  await writeAuditReceipt({
+    at: new Date().toISOString(),
+    requestedBy: request.requestedBy,
+    backendId: receipt.backendId,
+    methodId: receipt.methodId,
+    platform: receipt.platform,
+    executable: receipt.executable,
+    commandHash: receipt.commandHash,
+    exitCode: receipt.exitCode,
+  });
+
+  if (receipt.exitCode !== 0) {
+    throw new Error(
+      `Vault installer failed for ${request.backendId}:${request.methodId} with exit code ${receipt.exitCode}`,
+    );
+  }
+
+  return receipt;
+}
+
+async function spawnAndCapture(
+  command: string,
+  args: readonly string[],
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Vault installer timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref();
+
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      resolvePromise({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+async function writeAuditReceipt(receipt: Record<string, unknown>): Promise<void> {
+  const target = resolve(
+    process.env.SKYGRID_VAULT_INSTALL_AUDIT_PATH ?? DEFAULT_AUDIT_PATH,
+  );
+  await mkdir(dirname(target), { recursive: true });
+  await appendFile(target, `${JSON.stringify(receipt)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+function truncate(value: string, max = 8_000): string {
+  const cleaned = value.replace(/\u001b\[[0-9;]*m/g, "").trim();
+  return cleaned.length > max ? `${cleaned.slice(0, max)}…` : cleaned;
+}

--- a/packages/vault/src/install.ts
+++ b/packages/vault/src/install.ts
@@ -1,0 +1,294 @@
+/**
+ * SKYGRID vault installer policy.
+ *
+ * This module is intentionally limited to install specs, host capability
+ * detection, and canonical command construction. It never executes an install.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+
+export type BackendId = "1password" | "bitwarden" | "protonpass";
+export type SupportedPlatform = "darwin" | "linux" | "win32";
+export type PackageManagerKind = "brew" | "npm";
+
+export type AutomatedInstallMethod =
+  | {
+      readonly id: string;
+      readonly kind: "brew";
+      readonly package: string;
+      readonly cask: boolean;
+      readonly version?: string;
+      readonly executable: string;
+    }
+  | {
+      readonly id: string;
+      readonly kind: "npm";
+      readonly package: string;
+      readonly version: string;
+      readonly executable: string;
+    };
+
+export type ManualInstallMethod = {
+  readonly id: string;
+  readonly kind: "manual";
+  readonly instructions: string;
+  readonly url: string;
+  readonly executable: string;
+};
+
+export type InstallMethod = AutomatedInstallMethod | ManualInstallMethod;
+
+export interface BackendInstallSpec {
+  readonly id: BackendId;
+  readonly methods: Readonly<
+    Partial<Record<SupportedPlatform, readonly InstallMethod[]>>
+  >;
+}
+
+const BITWARDEN_CLI_VERSION = "2026.7.0";
+
+/**
+ * Canonical allowlist. Client requests identify only backendId + methodId;
+ * package names, versions, commands, URLs, and argv are never client supplied.
+ */
+export const BACKEND_INSTALL_SPECS: Readonly<
+  Record<BackendId, BackendInstallSpec>
+> = {
+  "1password": {
+    id: "1password",
+    methods: {
+      darwin: [
+        {
+          id: "brew-cask",
+          kind: "brew",
+          package: "1password-cli",
+          cask: true,
+          executable: "op",
+        },
+        {
+          id: "manual",
+          kind: "manual",
+          executable: "op",
+          instructions:
+            "Install the 1Password CLI using the official platform instructions.",
+          url: "https://developer.1password.com/docs/cli/get-started/",
+        },
+      ],
+      linux: [
+        {
+          id: "manual",
+          kind: "manual",
+          executable: "op",
+          instructions:
+            "Install the 1Password CLI using the official signed-package instructions.",
+          url: "https://developer.1password.com/docs/cli/get-started/",
+        },
+      ],
+      win32: [
+        {
+          id: "manual",
+          kind: "manual",
+          executable: "op",
+          instructions:
+            "Install the 1Password CLI with the official Windows installer or winget instructions.",
+          url: "https://developer.1password.com/docs/cli/get-started/",
+        },
+      ],
+    },
+  },
+  bitwarden: {
+    id: "bitwarden",
+    methods: {
+      darwin: [
+        {
+          id: "npm-pinned",
+          kind: "npm",
+          package: "@bitwarden/cli",
+          version: BITWARDEN_CLI_VERSION,
+          executable: "bw",
+        },
+        {
+          id: "brew",
+          kind: "brew",
+          package: "bitwarden-cli",
+          cask: false,
+          executable: "bw",
+        },
+      ],
+      linux: [
+        {
+          id: "npm-pinned",
+          kind: "npm",
+          package: "@bitwarden/cli",
+          version: BITWARDEN_CLI_VERSION,
+          executable: "bw",
+        },
+      ],
+      win32: [
+        {
+          id: "npm-pinned",
+          kind: "npm",
+          package: "@bitwarden/cli",
+          version: BITWARDEN_CLI_VERSION,
+          executable: "bw",
+        },
+      ],
+    },
+  },
+  protonpass: {
+    id: "protonpass",
+    methods: {
+      darwin: [
+        {
+          id: "brew-official-tap",
+          kind: "brew",
+          package: "protonpass/tap/pass-cli",
+          cask: false,
+          executable: "pass-cli",
+        },
+        {
+          id: "manual",
+          kind: "manual",
+          executable: "pass-cli",
+          instructions:
+            "Install Proton Pass CLI with the official installer or verified manual download.",
+          url: "https://protonpass.github.io/pass-cli/get-started/installation/",
+        },
+      ],
+      linux: [
+        {
+          id: "brew-official-tap",
+          kind: "brew",
+          package: "protonpass/tap/pass-cli",
+          cask: false,
+          executable: "pass-cli",
+        },
+        {
+          id: "manual",
+          kind: "manual",
+          executable: "pass-cli",
+          instructions:
+            "Install Proton Pass CLI with the official installer or verified manual download.",
+          url: "https://protonpass.github.io/pass-cli/get-started/installation/",
+        },
+      ],
+      win32: [
+        {
+          id: "manual",
+          kind: "manual",
+          executable: "pass-cli.exe",
+          instructions:
+            "Install Proton Pass CLI using the official PowerShell installer or verified manual download.",
+          url: "https://protonpass.github.io/pass-cli/get-started/installation/",
+        },
+      ],
+    },
+  },
+};
+
+export interface PackageManagerAvailability {
+  readonly brew: boolean;
+  readonly npm: boolean;
+}
+
+let packageManagerCache: PackageManagerAvailability | null = null;
+
+export function currentPlatform(): SupportedPlatform | null {
+  const platform = process.platform;
+  return platform === "darwin" || platform === "linux" || platform === "win32"
+    ? platform
+    : null;
+}
+
+function packageManagerCommand(
+  kind: PackageManagerKind,
+  platform: SupportedPlatform,
+): string | null {
+  if (kind === "brew") return platform === "win32" ? null : "brew";
+  return platform === "win32" ? "npm.cmd" : "npm";
+}
+
+async function isPackageManagerRunnable(
+  kind: PackageManagerKind,
+  platform: SupportedPlatform,
+): Promise<boolean> {
+  const command = packageManagerCommand(kind, platform);
+  if (!command) return false;
+  try {
+    await exec(command, ["--version"], { timeout: 5_000, windowsHide: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPackageManagers(
+  platform: SupportedPlatform | null = currentPlatform(),
+): Promise<PackageManagerAvailability> {
+  if (!platform) return { brew: false, npm: false };
+  if (packageManagerCache) return packageManagerCache;
+  const [brew, npm] = await Promise.all([
+    isPackageManagerRunnable("brew", platform),
+    isPackageManagerRunnable("npm", platform),
+  ]);
+  packageManagerCache = { brew, npm };
+  return packageManagerCache;
+}
+
+export function resetInstallerCache(): void {
+  packageManagerCache = null;
+}
+
+export async function resolveRunnableMethods(
+  backendId: BackendId,
+  platform: SupportedPlatform | null = currentPlatform(),
+): Promise<readonly InstallMethod[]> {
+  if (!platform) return [];
+  const candidates = BACKEND_INSTALL_SPECS[backendId].methods[platform] ?? [];
+  if (candidates.length === 0) return [];
+  const tools = await detectPackageManagers(platform);
+  return candidates.filter((method) => {
+    if (method.kind === "manual") return true;
+    if (method.kind === "brew") return tools.brew;
+    return tools.npm;
+  });
+}
+
+export async function resolveAllowedInstallMethod(
+  backendId: BackendId,
+  methodId: string,
+  platform: SupportedPlatform | null = currentPlatform(),
+): Promise<AutomatedInstallMethod> {
+  if (!platform) throw new Error(`Unsupported platform: ${process.platform}`);
+  const methods = await resolveRunnableMethods(backendId, platform);
+  const method = methods.find((candidate) => candidate.id === methodId);
+  if (!method) {
+    throw new Error(
+      `Install method ${backendId}:${methodId} is not allowed or runnable on ${platform}`,
+    );
+  }
+  if (method.kind === "manual") {
+    throw new Error(`Install method ${backendId}:${methodId} is manual-only`);
+  }
+  return method;
+}
+
+export function buildInstallCommand(method: AutomatedInstallMethod): {
+  readonly command: string;
+  readonly args: readonly string[];
+} {
+  if (method.kind === "brew") {
+    return {
+      command: "brew",
+      args: method.cask
+        ? ["install", "--cask", method.package]
+        : ["install", method.package],
+    };
+  }
+  return {
+    command: process.platform === "win32" ? "npm.cmd" : "npm",
+    args: ["install", "-g", `${method.package}@${method.version}`],
+  };
+}


### PR DESCRIPTION
## What changed

- adds `packages/vault/src/install.ts` as the canonical install-policy and package-manager detection layer
- adds `packages/operator/src/vault-installer.ts` as the only guarded execution boundary
- adds OWNER-gated `/api/admin/vault/install-methods` and `/api/admin/vault/install` handlers
- enables the install API surface by default while blocking execution in CI and Vercel/serverless runtimes
- accepts only `backendId + methodId`; package names, commands, URLs, and argv are resolved server-side from a static allowlist
- pins the Bitwarden npm CLI path and keeps `shell: false` for execution
- writes non-secret audit receipts with command hashes and exit status
- adds an isolated GitHub Actions review workflow that type-checks these files and enforces trust-boundary invariants

## Why

This separates vault install specification from privileged execution and prevents a network-facing caller from turning the installer endpoint into arbitrary package or command execution.

## Operator impact

The API routes are present by default but fail closed without `SKYGRID_OWNER_TOKEN`. Installation can run only on an operator host; CI and Vercel expose no install execution capability. Manual vendor install paths remain discoverable.

## Validation

- local isolated TypeScript strict check passed against the five implementation files
- local policy scan passed: no `shell: true`, no caller-supplied package/command/args/url fields, canonical `methodId` resolution required
- PR workflow repeats the isolated type-check and policy scan on GitHub Actions

## Review focus

1. OWNER token integration with the existing control-plane auth model
2. whether operator-host execution should additionally require an explicit deployment role flag
3. audit-receipt destination and future `.pnpk` signing integration
4. package/version pinning policy for brew-managed CLIs
